### PR TITLE
Add idea-flow plugin for OpenClaw -> Claude Code flow

### DIFF
--- a/plugins/idea-flow/index.ts
+++ b/plugins/idea-flow/index.ts
@@ -1,0 +1,201 @@
+/**
+ * Idea Flow Plugin for OpenClaw
+ *
+ * This plugin provides a complete idea-to-implementation pipeline
+ * using Claude Code web sessions for GitHub issue creation, planning,
+ * and implementation.
+ */
+
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+
+import { createStateManager, StateManager } from './src/state.js';
+import { createNotificationManager, NotificationManager } from './src/notifications.js';
+import { createSessionManager, ClaudeCodeSessionManager } from './src/claude-code/session-manager.js';
+import type { PluginConfig, IdeaStatus } from './src/types.js';
+
+import {
+  ideaCaptureDefinition,
+  ideaClarifyDefinition,
+  ideaListDefinition,
+  ideaStatusDefinition,
+  ideaHistoryDefinition,
+  ideaToIssueDefinition,
+  ideaPlanDefinition,
+  ideaImplementDefinition,
+  ideaModifyDefinition,
+  ideaDeleteDefinition,
+  captureIdea,
+  clarifyIdea,
+  listIdeas,
+  getIdeaStatus,
+  getIdeaHistory,
+  ideaToIssue,
+  planIdea,
+  implementIdea,
+  modifyIdea,
+  deleteIdea,
+} from './src/tools/index.js';
+
+export default function register(api: OpenClawPluginApi) {
+  const pluginConfig = (api.pluginConfig ?? {}) as Partial<PluginConfig>;
+
+  // Validate required config
+  if (!pluginConfig.defaultRepo) {
+    console.error('Idea Flow: defaultRepo is required in plugin config');
+    return;
+  }
+
+  // Initialize config with defaults
+  const config: PluginConfig = {
+    defaultRepo: pluginConfig.defaultRepo,
+    claudeCodeEnvironment: pluginConfig.claudeCodeEnvironment,
+    statePath: pluginConfig.statePath || '~/.idea-flow',
+    autoNotify: pluginConfig.autoNotify !== false,
+    requirePlanBeforeImplement: pluginConfig.requirePlanBeforeImplement !== false,
+  };
+
+  // Initialize managers
+  const state = createStateManager(config.statePath);
+  const notificationManager = createNotificationManager(config, state);
+  const sessionManager = createSessionManager(config);
+
+  // ============================================================================
+  // Read Tools (Always Available)
+  // ============================================================================
+
+  // idea_list
+  api.registerTool({
+    name: ideaListDefinition.name,
+    description: ideaListDefinition.description,
+    parameters: ideaListDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return listIdeas(state, {
+        status: params.status as IdeaStatus | undefined,
+        limit: params.limit as number | undefined,
+      });
+    },
+  });
+
+  // idea_status
+  api.registerTool({
+    name: ideaStatusDefinition.name,
+    description: ideaStatusDefinition.description,
+    parameters: ideaStatusDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return getIdeaStatus(state, notificationManager, {
+        ideaId: params.ideaId as string,
+      });
+    },
+  });
+
+  // idea_history
+  api.registerTool({
+    name: ideaHistoryDefinition.name,
+    description: ideaHistoryDefinition.description,
+    parameters: ideaHistoryDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return getIdeaHistory(state, {
+        ideaId: params.ideaId as string,
+      });
+    },
+  });
+
+  // ============================================================================
+  // Write Tools
+  // ============================================================================
+
+  // idea_capture
+  api.registerTool({
+    name: ideaCaptureDefinition.name,
+    description: ideaCaptureDefinition.description,
+    parameters: ideaCaptureDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return captureIdea(state, config, {
+        title: params.title as string,
+        description: params.description as string,
+        repo: params.repo as string | undefined,
+      });
+    },
+  });
+
+  // idea_clarify
+  api.registerTool({
+    name: ideaClarifyDefinition.name,
+    description: ideaClarifyDefinition.description,
+    parameters: ideaClarifyDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return clarifyIdea(state, {
+        ideaId: params.ideaId as string,
+        question: params.question as string,
+        answer: params.answer as string,
+        updateDescription: params.updateDescription as boolean | undefined,
+      });
+    },
+  });
+
+  // idea_to_issue
+  api.registerTool({
+    name: ideaToIssueDefinition.name,
+    description: ideaToIssueDefinition.description,
+    parameters: ideaToIssueDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return ideaToIssue(state, sessionManager, notificationManager, {
+        ideaId: params.ideaId as string,
+        dryRun: params.dryRun as boolean | undefined,
+      });
+    },
+  });
+
+  // idea_plan
+  api.registerTool({
+    name: ideaPlanDefinition.name,
+    description: ideaPlanDefinition.description,
+    parameters: ideaPlanDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return planIdea(state, sessionManager, notificationManager, {
+        ideaId: params.ideaId as string,
+      });
+    },
+  });
+
+  // idea_implement
+  api.registerTool({
+    name: ideaImplementDefinition.name,
+    description: ideaImplementDefinition.description,
+    parameters: ideaImplementDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return implementIdea(state, sessionManager, notificationManager, config, {
+        ideaId: params.ideaId as string,
+        skipPlan: params.skipPlan as boolean | undefined,
+      });
+    },
+  });
+
+  // idea_modify
+  api.registerTool({
+    name: ideaModifyDefinition.name,
+    description: ideaModifyDefinition.description,
+    parameters: ideaModifyDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return modifyIdea(state, sessionManager, notificationManager, {
+        ideaId: params.ideaId as string,
+        modificationRequest: params.modificationRequest as string,
+        target: params.target as 'issue' | 'plan' | 'implementation',
+      });
+    },
+  });
+
+  // idea_delete
+  api.registerTool({
+    name: ideaDeleteDefinition.name,
+    description: ideaDeleteDefinition.description,
+    parameters: ideaDeleteDefinition.parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      return deleteIdea(state, notificationManager, {
+        ideaId: params.ideaId as string,
+        closeIssue: params.closeIssue as boolean | undefined,
+        closePR: params.closePR as boolean | undefined,
+      });
+    },
+  });
+}

--- a/plugins/idea-flow/openclaw.plugin.json
+++ b/plugins/idea-flow/openclaw.plugin.json
@@ -1,0 +1,59 @@
+{
+  "id": "idea-flow",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "defaultRepo": {
+        "type": "string",
+        "description": "Default repository (owner/repo format)"
+      },
+      "claudeCodeEnvironment": {
+        "type": "string",
+        "description": "Name of Claude Code web environment to use"
+      },
+      "statePath": {
+        "type": "string",
+        "default": "~/.idea-flow",
+        "description": "Path to store idea state files"
+      },
+      "autoNotify": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically notify user when tasks complete"
+      },
+      "requirePlanBeforeImplement": {
+        "type": "boolean",
+        "default": true,
+        "description": "Require an implementation plan before starting implementation"
+      }
+    },
+    "required": ["defaultRepo"],
+    "uiHints": {
+      "defaultRepo": {
+        "helpText": "Format: owner/repo (e.g., myorg/myproject)"
+      },
+      "claudeCodeEnvironment": {
+        "helpText": "Leave blank to use default Claude Code environment"
+      }
+    }
+  },
+  "tools": {
+    "read": [
+      "idea_list",
+      "idea_status",
+      "idea_history"
+    ],
+    "write": [
+      "idea_capture",
+      "idea_clarify",
+      "idea_to_issue",
+      "idea_plan",
+      "idea_implement",
+      "idea_modify",
+      "idea_delete"
+    ]
+  },
+  "skills": [
+    "idea-flow"
+  ]
+}

--- a/plugins/idea-flow/package.json
+++ b/plugins/idea-flow/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@openclaw/idea-flow",
+  "version": "1.0.0",
+  "description": "Idea-to-implementation pipeline via Claude Code for OpenClaw",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "jest",
+    "lint": "eslint src/**/*.ts",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "skills"
+  ],
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "idea-flow",
+    "claude-code",
+    "github",
+    "issue-tracking"
+  ],
+  "license": "MIT"
+}

--- a/plugins/idea-flow/skills/idea-flow/SKILL.md
+++ b/plugins/idea-flow/skills/idea-flow/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: idea-flow
+description: Transform ideas into implemented features through Claude Code - capture, clarify, create issues, plan, and implement
+user-invocable: true
+---
+
+# Idea Flow - Idea to Implementation Pipeline
+
+You are helping the user transform ideas into implemented features through a structured workflow that leverages Claude Code web sessions.
+
+## Overview
+
+This skill enables a complete idea-to-implementation pipeline:
+1. **Capture** - User shares an idea, you capture it
+2. **Clarify** - Ask questions to refine requirements
+3. **Issue** - Create a GitHub issue via Claude Code
+4. **Plan** - Generate implementation plan via Claude Code Plan agent
+5. **Implement** - Execute implementation via Claude Code
+
+## Available Tools
+
+### Read Tools
+- `idea_list` - List all ideas with their current status
+- `idea_status` - Get detailed status of a specific idea
+- `idea_history` - View full history including clarifications and sessions
+
+### Write Tools
+- `idea_capture` - Start capturing a new idea
+- `idea_clarify` - Record clarifying Q&A for an idea
+- `idea_to_issue` - Hand off to Claude Code to create GitHub issue
+- `idea_plan` - Hand off to Claude Code Plan agent to generate implementation plan
+- `idea_implement` - Hand off to Claude Code to implement the feature
+- `idea_modify` - Request changes to existing work (issue, plan, or implementation)
+- `idea_delete` - Delete/close an idea and associated artifacts
+
+## Workflow: New Idea
+
+When a user shares a new idea:
+
+1. **Capture immediately** using `idea_capture`
+   - Extract a concise title (2-10 words)
+   - Summarize the initial description
+
+2. **Ask clarifying questions** (aim for 2-5)
+   - Technical scope and boundaries
+   - Expected behavior and edge cases
+   - Dependencies and integrations
+   - Success criteria
+
+3. **Record each clarification** using `idea_clarify`
+
+4. **When requirements are clear**, offer to create GitHub issue:
+   "I have a good understanding of your idea. Ready to create a GitHub issue?"
+
+5. **Create issue** using `idea_to_issue`
+   - Claude Code will create a well-structured issue
+   - User will be notified with the issue link
+
+## Workflow: Planning
+
+When user says "plan this" or "create implementation plan":
+
+1. Verify an issue exists (use `idea_status`)
+2. Call `idea_plan` to trigger Claude Code Plan agent
+3. Claude Code will:
+   - Explore the codebase
+   - Generate detailed implementation plan
+   - Post plan as comment on the issue
+4. User receives notification with plan link
+
+## Workflow: Implementation
+
+When user says "implement this" or "build this feature":
+
+1. Check if plan exists (recommended before implementation)
+2. If no plan, suggest creating one first
+3. Call `idea_implement` to start implementation
+4. Claude Code will:
+   - Create feature branch
+   - Implement changes following the plan
+   - Run tests
+   - Create pull request
+5. User receives notification with PR link
+
+## Workflow: Modifications
+
+When user wants changes to existing work:
+
+1. Identify the target: issue, plan, or implementation
+2. Use `idea_modify` with clear modification request
+3. Claude Code resumes the session and makes changes
+4. User receives notification when complete
+
+## Important Rules
+
+### Handoff Communication
+- Always explain what Claude Code will do before handing off
+- Provide status updates and links after each handoff
+- Let user know they'll be notified when complete
+
+### Safety First
+- Never skip clarification for complex ideas
+- Always recommend planning before implementation
+- Confirm destructive actions (delete, major changes)
+
+### Session Tracking
+- Each Claude Code task creates a tracked session
+- Sessions can be resumed for modifications
+- Full history is maintained for audit
+
+## Idea Lifecycle States
+
+```
+draft → clarifying → issue_creating → issue_ready
+                                          ↓
+                         planning → planned → implementing → implemented → completed
+                                                    ↑
+                                              modification
+```
+
+## Example Interactions
+
+### "I have an idea for a new feature"
+```
+1. "That sounds interesting! Let me capture this idea."
+2. Call idea_capture with title and description
+3. "I've recorded your idea. Let me ask a few questions to clarify..."
+4. Ask 2-5 clarifying questions
+5. Record answers with idea_clarify
+6. "Ready to create a GitHub issue for this?"
+```
+
+### "Create an issue from my idea"
+```
+1. Check idea exists with idea_status
+2. Call idea_to_issue
+3. "I'm handing this off to Claude Code to create the GitHub issue.
+    You'll be notified when it's ready."
+```
+
+### "Plan the implementation"
+```
+1. Verify issue exists
+2. Call idea_plan
+3. "Claude Code is analyzing the codebase and generating an implementation
+    plan. This will be posted as a comment on the issue."
+```
+
+### "Implement it"
+```
+1. Check if plan exists (warn if not)
+2. Call idea_implement
+3. "Claude Code is implementing the feature. You'll receive the PR link
+    when complete."
+```
+
+### "Make changes to the issue"
+```
+1. Get the idea ID and verify issue exists
+2. Call idea_modify with target: "issue"
+3. "Claude Code is updating the issue with your requested changes."
+```
+
+### "Delete this idea"
+```
+1. Confirm with user: "Are you sure? This will remove the idea from tracking."
+2. Ask about GitHub artifacts: "Should I also close the issue/PR?"
+3. Call idea_delete with appropriate options
+```
+
+## Response Format
+
+When presenting data:
+- Show idea IDs in short form: [abc123]
+- Display status clearly
+- Indicate what artifacts exist (Issue, Plan, PR)
+- Show available actions based on current state
+
+When making changes:
+- Always explain what Claude Code will do
+- Provide session URLs for tracking
+- Confirm completion or provide next steps

--- a/plugins/idea-flow/src/claude-code/parsers.ts
+++ b/plugins/idea-flow/src/claude-code/parsers.ts
@@ -1,0 +1,268 @@
+/**
+ * Output parsing utilities for Claude Code session results
+ * Extracts URLs, issue numbers, PR info, and plans from session output
+ */
+
+import type { StreamMessage, ImplementationPlan, PlanStep, CriticalFile } from '../types.js';
+
+/**
+ * Extract GitHub issue URL from session messages
+ */
+export function extractIssueUrl(messages: StreamMessage[]): string | null {
+  for (const message of messages) {
+    if (message.content) {
+      // Match GitHub issue URLs
+      const match = message.content.match(
+        /https:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/
+      );
+      if (match) {
+        return match[0];
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract issue number from URL
+ */
+export function extractIssueNumber(issueUrl: string | null): number | null {
+  if (!issueUrl) return null;
+  const match = issueUrl.match(/\/issues\/(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Extract GitHub PR URL from session messages
+ */
+export function extractPRUrl(messages: StreamMessage[]): string | null {
+  for (const message of messages) {
+    if (message.content) {
+      // Match GitHub PR URLs
+      const match = message.content.match(
+        /https:\/\/github\.com\/[\w-]+\/[\w-]+\/pull\/\d+/
+      );
+      if (match) {
+        return match[0];
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract PR number from URL
+ */
+export function extractPRNumber(prUrl: string | null): number | null {
+  if (!prUrl) return null;
+  const match = prUrl.match(/\/pull\/(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Extract GitHub comment URL from session messages
+ */
+export function extractCommentUrl(messages: StreamMessage[]): string | null {
+  for (const message of messages) {
+    if (message.content) {
+      // Match GitHub issue comment URLs
+      const match = message.content.match(
+        /https:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+#issuecomment-\d+/
+      );
+      if (match) {
+        return match[0];
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract branch name from session messages
+ */
+export function extractBranch(messages: StreamMessage[]): string | null {
+  for (const message of messages) {
+    if (message.content) {
+      // Match common branch patterns
+      const patterns = [
+        /git checkout -b ([\w-/]+)/,
+        /branch[:\s]+'?([\w-/]+)'?/i,
+        /feature\/[\w-]+/,
+      ];
+
+      for (const pattern of patterns) {
+        const match = message.content.match(pattern);
+        if (match) {
+          return match[1] || match[0];
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract implementation plan from session messages
+ * Parses structured plan content from Claude Code output
+ */
+export function extractPlan(messages: StreamMessage[]): ImplementationPlan | null {
+  let planContent = '';
+
+  // Collect all content that might contain plan information
+  for (const message of messages) {
+    if (message.content) {
+      planContent += message.content + '\n';
+    }
+  }
+
+  if (!planContent.includes('Implementation Plan') && !planContent.includes('## Plan')) {
+    return null;
+  }
+
+  try {
+    // Extract summary (first paragraph after plan header)
+    const summaryMatch = planContent.match(
+      /(?:Implementation Plan|## Plan)[:\s]*\n+([^\n]+(?:\n[^\n#]+)*)/i
+    );
+    const summary = summaryMatch ? summaryMatch[1].trim() : 'Implementation plan generated';
+
+    // Extract steps (numbered list items)
+    const steps: PlanStep[] = [];
+    const stepMatches = planContent.matchAll(
+      /(\d+)\.\s+([^\n]+)(?:\n\s+[-*]\s+([^\n]+))?/g
+    );
+    for (const match of stepMatches) {
+      steps.push({
+        order: parseInt(match[1], 10),
+        description: match[2].trim(),
+        filesInvolved: match[3] ? [match[3].trim()] : [],
+      });
+    }
+
+    // Extract critical files
+    const criticalFiles: CriticalFile[] = [];
+    const fileMatches = planContent.matchAll(
+      /[-*]\s+`([^`]+)`\s*[-:]\s*([^\n]+)/g
+    );
+    for (const match of fileMatches) {
+      criticalFiles.push({
+        path: match[1],
+        reason: match[2].trim(),
+      });
+    }
+
+    // Extract risks
+    const risks: string[] = [];
+    const riskSection = planContent.match(/(?:Risks?|Blockers?)[:\s]*\n((?:[-*]\s+[^\n]+\n?)+)/i);
+    if (riskSection) {
+      const riskMatches = riskSection[1].matchAll(/[-*]\s+([^\n]+)/g);
+      for (const match of riskMatches) {
+        risks.push(match[1].trim());
+      }
+    }
+
+    // Estimate complexity based on steps and files
+    let estimatedComplexity: 'low' | 'medium' | 'high' = 'medium';
+    if (steps.length <= 3 && criticalFiles.length <= 5) {
+      estimatedComplexity = 'low';
+    } else if (steps.length > 10 || criticalFiles.length > 15) {
+      estimatedComplexity = 'high';
+    }
+
+    return {
+      summary,
+      steps: steps.length > 0 ? steps : [{ order: 1, description: summary, filesInvolved: [] }],
+      criticalFiles,
+      risks,
+      estimatedComplexity,
+      postedAsComment: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if session output indicates success
+ */
+export function isSessionSuccessful(messages: StreamMessage[]): boolean {
+  for (const message of messages) {
+    if (message.content) {
+      // Check for common success indicators
+      if (
+        message.content.includes('successfully created') ||
+        message.content.includes('PR created') ||
+        message.content.includes('issue created') ||
+        message.content.includes('plan posted')
+      ) {
+        return true;
+      }
+
+      // Check for URLs which indicate successful creation
+      if (
+        message.content.includes('github.com') &&
+        (message.content.includes('/issues/') ||
+          message.content.includes('/pull/') ||
+          message.content.includes('#issuecomment-'))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Extract error message from session output
+ */
+export function extractError(messages: StreamMessage[]): string | null {
+  for (const message of messages) {
+    if (message.content) {
+      // Check for common error patterns
+      const errorPatterns = [
+        /error[:\s]+([^\n]+)/i,
+        /failed[:\s]+([^\n]+)/i,
+        /permission denied[:\s]*([^\n]*)/i,
+        /not found[:\s]*([^\n]*)/i,
+      ];
+
+      for (const pattern of errorPatterns) {
+        const match = message.content.match(pattern);
+        if (match) {
+          return match[0];
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse all relevant data from session messages
+ */
+export function parseSessionOutput(messages: StreamMessage[]): {
+  issueUrl: string | null;
+  issueNumber: number | null;
+  prUrl: string | null;
+  prNumber: number | null;
+  commentUrl: string | null;
+  branch: string | null;
+  plan: ImplementationPlan | null;
+  success: boolean;
+  error: string | null;
+} {
+  const issueUrl = extractIssueUrl(messages);
+  const prUrl = extractPRUrl(messages);
+
+  return {
+    issueUrl,
+    issueNumber: extractIssueNumber(issueUrl),
+    prUrl,
+    prNumber: extractPRNumber(prUrl),
+    commentUrl: extractCommentUrl(messages),
+    branch: extractBranch(messages),
+    plan: extractPlan(messages),
+    success: isSessionSuccessful(messages),
+    error: extractError(messages),
+  };
+}

--- a/plugins/idea-flow/src/claude-code/session-manager.ts
+++ b/plugins/idea-flow/src/claude-code/session-manager.ts
@@ -1,0 +1,246 @@
+/**
+ * Claude Code Session Manager
+ * Manages Claude Code web sessions for issue creation, planning, and implementation
+ */
+
+import type {
+  PluginConfig,
+  SessionPurpose,
+  SessionParams,
+  SessionStartResult,
+  SessionResumeResult,
+  StreamMessage,
+  ClarificationEntry,
+  ImplementationPlan,
+} from '../types.js';
+
+/**
+ * Manages Claude Code web sessions
+ * Note: In production, this would use the Claude Agent SDK for programmatic control
+ * For now, this provides the interface and prompt generation
+ */
+export class ClaudeCodeSessionManager {
+  private config: PluginConfig;
+
+  constructor(config: PluginConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Start a Claude Code web session for a specific purpose
+   * In production, this would use the Claude Agent SDK
+   */
+  async startSession(
+    purpose: SessionPurpose,
+    params: SessionParams
+  ): Promise<SessionStartResult> {
+    const prompt = this.buildPrompt(purpose, params);
+    const sessionId = this.generateSessionId();
+
+    // In production, this would call the Claude Agent SDK:
+    // const response = await query({
+    //   prompt,
+    //   options: {
+    //     model: "claude-sonnet-4-5",
+    //     allowedTools: this.getToolsForPurpose(purpose),
+    //     remote: true,
+    //     environment: this.config.claudeCodeEnvironment
+    //   }
+    // });
+
+    // For now, return a simulated result with the generated prompt
+    // The actual execution would happen in the Claude Code web session
+    return {
+      sessionId,
+      claudeCodeUrl: `https://claude.ai/code/session_${sessionId}`,
+      messages: [
+        {
+          type: 'system',
+          subtype: 'init',
+          session_id: sessionId,
+        },
+        {
+          type: 'prompt',
+          content: prompt,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Resume an existing session to continue work
+   */
+  async resumeSession(
+    sessionId: string,
+    additionalPrompt: string,
+    fork: boolean = false
+  ): Promise<SessionResumeResult> {
+    // In production, this would use the Claude Agent SDK to resume
+    // For now, return the additional prompt context
+    const newSessionId = fork ? this.generateSessionId() : sessionId;
+
+    return {
+      sessionId: newSessionId,
+      messages: [
+        {
+          type: 'prompt',
+          content: additionalPrompt,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Build appropriate prompt for each session purpose
+   */
+  buildPrompt(purpose: SessionPurpose, params: SessionParams): string {
+    switch (purpose) {
+      case 'issue_creation':
+        return this.buildIssueCreationPrompt(params);
+      case 'planning':
+        return this.buildPlanningPrompt(params);
+      case 'implementation':
+        return this.buildImplementationPrompt(params);
+      case 'modification':
+        return this.buildModificationPrompt(params);
+    }
+  }
+
+  private buildIssueCreationPrompt(params: SessionParams): string {
+    const clarificationsText = params.clarifications?.length
+      ? params.clarifications
+          .map((c) => `- Q: ${c.question}\n  A: ${c.answer}`)
+          .join('\n')
+      : 'None';
+
+    return `Create a GitHub issue for the following feature request.
+
+**Repository**: ${params.repo}
+
+**Title**: ${params.title || 'Untitled'}
+
+**Requirements**:
+${params.description || 'No description provided'}
+
+**Clarifications gathered**:
+${clarificationsText}
+
+Instructions:
+1. Create a well-structured GitHub issue using the gh CLI
+2. Include:
+   - Clear title
+   - Problem statement / motivation
+   - Detailed requirements
+   - Acceptance criteria
+   - Technical considerations (if applicable)
+3. Add appropriate labels if you can determine them
+4. Return the issue URL when complete
+
+Use: gh issue create --repo ${params.repo} --title "..." --body "..."`;
+  }
+
+  private buildPlanningPrompt(params: SessionParams): string {
+    return `Generate an implementation plan for GitHub issue #${params.issueNumber}.
+
+**Repository**: ${params.repo}
+**Issue**: ${params.issueUrl}
+
+Instructions:
+1. Read the issue to understand requirements
+2. Explore the codebase to understand architecture
+3. Create a detailed implementation plan including:
+   - Step-by-step implementation strategy
+   - Critical files to modify/create
+   - Architectural trade-offs and considerations
+   - Potential risks or blockers
+   - Recommended order of implementation
+4. Post the plan as a comment on the issue using:
+   gh issue comment ${params.issueNumber} --repo ${params.repo} --body "## Implementation Plan\n..."
+5. Return the comment URL when complete`;
+  }
+
+  private buildImplementationPrompt(params: SessionParams): string {
+    const planText = params.plan
+      ? `\n**Implementation Plan**:\n${params.plan.summary}\n\nSteps:\n${params.plan.steps.map((s) => `${s.order}. ${s.description}`).join('\n')}`
+      : '';
+
+    return `Implement the feature described in GitHub issue #${params.issueNumber}.
+
+**Repository**: ${params.repo}
+**Issue**: ${params.issueUrl}${planText}
+
+Instructions:
+1. Create a new branch for this feature (e.g., feature/issue-${params.issueNumber})
+2. Implement the changes following the plan
+3. Write tests where appropriate
+4. Ensure all tests pass
+5. Create a pull request linked to the issue
+6. Return the PR URL when complete
+
+Use:
+- git checkout -b feature/issue-${params.issueNumber}
+- [make changes]
+- git add . && git commit -m "..."
+- git push -u origin feature/issue-${params.issueNumber}
+- gh pr create --repo ${params.repo} --title "..." --body "Closes #${params.issueNumber}\n\n..."`;
+  }
+
+  private buildModificationPrompt(params: SessionParams): string {
+    return `Make modifications to the existing work on issue #${params.issueNumber}.
+
+**Repository**: ${params.repo}
+**Issue**: ${params.issueUrl}
+**Requested changes**: ${params.modificationRequest}
+
+Instructions:
+1. Review the current state of the branch/PR
+2. Make the requested modifications
+3. Ensure tests still pass
+4. Update the PR description if needed
+5. Push the changes
+
+Use:
+- git pull
+- [make modifications]
+- git add . && git commit -m "Address review: ${params.modificationRequest?.slice(0, 50)}..."
+- git push`;
+  }
+
+  /**
+   * Get allowed tools for each session purpose
+   */
+  getToolsForPurpose(purpose: SessionPurpose): string[] {
+    const baseTools = ['Read', 'Glob', 'Grep', 'Bash'];
+
+    switch (purpose) {
+      case 'issue_creation':
+        return [...baseTools]; // Read-only + Bash for gh
+      case 'planning':
+        return [...baseTools]; // Read-only exploration
+      case 'implementation':
+      case 'modification':
+        return [...baseTools, 'Edit', 'Write']; // Full write access
+    }
+  }
+
+  /**
+   * Generate a unique session ID
+   */
+  private generateSessionId(): string {
+    return `${Date.now().toString(36)}${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  /**
+   * Get the prompt that was used for a session (for debugging)
+   */
+  getPromptForSession(purpose: SessionPurpose, params: SessionParams): string {
+    return this.buildPrompt(purpose, params);
+  }
+}
+
+/**
+ * Create a session manager instance
+ */
+export function createSessionManager(config: PluginConfig): ClaudeCodeSessionManager {
+  return new ClaudeCodeSessionManager(config);
+}

--- a/plugins/idea-flow/src/claude-code/session-manager.ts
+++ b/plugins/idea-flow/src/claude-code/session-manager.ts
@@ -1,8 +1,9 @@
 /**
  * Claude Code Session Manager
- * Manages Claude Code web sessions for issue creation, planning, and implementation
+ * Manages Claude Code sessions via CLI subprocess for issue creation, planning, and implementation
  */
 
+import { spawn, type ChildProcess } from 'child_process';
 import type {
   PluginConfig,
   SessionPurpose,
@@ -10,14 +11,21 @@ import type {
   SessionStartResult,
   SessionResumeResult,
   StreamMessage,
-  ClarificationEntry,
-  ImplementationPlan,
 } from '../types.js';
 
+export interface ClaudeSessionOptions {
+  model?: 'opus' | 'sonnet' | 'haiku';
+  maxTurns?: number;
+  allowedTools?: string[];
+  resume?: string;
+  verbose?: boolean;
+}
+
 /**
- * Manages Claude Code web sessions
- * Note: In production, this would use the Claude Agent SDK for programmatic control
- * For now, this provides the interface and prompt generation
+ * Manages Claude Code sessions via CLI subprocess
+ *
+ * Uses the claude CLI with --print --output-format stream-json flags
+ * to programmatically control Claude Code sessions.
  */
 export class ClaudeCodeSessionManager {
   private config: PluginConfig;
@@ -27,43 +35,33 @@ export class ClaudeCodeSessionManager {
   }
 
   /**
-   * Start a Claude Code web session for a specific purpose
-   * In production, this would use the Claude Agent SDK
+   * Start a Claude Code session for a specific purpose
    */
   async startSession(
     purpose: SessionPurpose,
     params: SessionParams
   ): Promise<SessionStartResult> {
     const prompt = this.buildPrompt(purpose, params);
-    const sessionId = this.generateSessionId();
+    const allowedTools = this.getToolsForPurpose(purpose);
 
-    // In production, this would call the Claude Agent SDK:
-    // const response = await query({
-    //   prompt,
-    //   options: {
-    //     model: "claude-sonnet-4-5",
-    //     allowedTools: this.getToolsForPurpose(purpose),
-    //     remote: true,
-    //     environment: this.config.claudeCodeEnvironment
-    //   }
-    // });
+    const options: ClaudeSessionOptions = {
+      model: 'sonnet',
+      allowedTools,
+      verbose: true,
+    };
 
-    // For now, return a simulated result with the generated prompt
-    // The actual execution would happen in the Claude Code web session
+    const messages = await this.runClaudeSession(prompt, options);
+
+    // Extract session ID from system message
+    const systemMessage = messages.find(
+      (m) => m.type === 'system' && m.subtype === 'init'
+    );
+    const sessionId = systemMessage?.session_id || this.generateSessionId();
+
     return {
       sessionId,
       claudeCodeUrl: `https://claude.ai/code/session_${sessionId}`,
-      messages: [
-        {
-          type: 'system',
-          subtype: 'init',
-          session_id: sessionId,
-        },
-        {
-          type: 'prompt',
-          content: prompt,
-        },
-      ],
+      messages,
     };
   }
 
@@ -73,21 +71,139 @@ export class ClaudeCodeSessionManager {
   async resumeSession(
     sessionId: string,
     additionalPrompt: string,
-    fork: boolean = false
+    _fork: boolean = false
   ): Promise<SessionResumeResult> {
-    // In production, this would use the Claude Agent SDK to resume
-    // For now, return the additional prompt context
-    const newSessionId = fork ? this.generateSessionId() : sessionId;
+    const options: ClaudeSessionOptions = {
+      model: 'sonnet',
+      resume: sessionId,
+      verbose: true,
+    };
+
+    const messages = await this.runClaudeSession(additionalPrompt, options);
+
+    // Check if we got a new session ID (forked)
+    const systemMessage = messages.find(
+      (m) => m.type === 'system' && m.subtype === 'init'
+    );
+    const newSessionId = systemMessage?.session_id || sessionId;
 
     return {
       sessionId: newSessionId,
-      messages: [
-        {
-          type: 'prompt',
-          content: additionalPrompt,
-        },
-      ],
+      messages,
     };
+  }
+
+  /**
+   * Run a Claude CLI session and collect all messages
+   */
+  private runClaudeSession(
+    prompt: string,
+    options: ClaudeSessionOptions
+  ): Promise<StreamMessage[]> {
+    return new Promise((resolve, reject) => {
+      const args = this.buildCliArgs(prompt, options);
+      const messages: StreamMessage[] = [];
+
+      let proc: ChildProcess;
+      try {
+        proc = spawn('claude', args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: process.env,
+        });
+      } catch (error) {
+        reject(new Error(`Failed to spawn claude CLI: ${error}`));
+        return;
+      }
+
+      let buffer = '';
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        buffer += data.toString();
+
+        // Parse newline-delimited JSON
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || ''; // Keep incomplete line in buffer
+
+        for (const line of lines) {
+          if (line.trim()) {
+            try {
+              const message = JSON.parse(line) as StreamMessage;
+              messages.push(message);
+            } catch {
+              // Non-JSON output, log for debugging
+              console.error('[claude-session] Non-JSON output:', line.substring(0, 100));
+            }
+          }
+        }
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        const stderr = data.toString();
+        // Claude CLI outputs progress to stderr, which is fine
+        if (!stderr.includes('Error') && !stderr.includes('error')) {
+          console.log('[claude-session] Progress:', stderr.trim());
+        } else {
+          console.error('[claude-session] Error:', stderr);
+        }
+      });
+
+      proc.on('error', (error) => {
+        reject(new Error(`Claude CLI error: ${error.message}`));
+      });
+
+      proc.on('close', (code) => {
+        // Process any remaining buffer
+        if (buffer.trim()) {
+          try {
+            const message = JSON.parse(buffer) as StreamMessage;
+            messages.push(message);
+          } catch {
+            // Ignore incomplete JSON
+          }
+        }
+
+        if (code === 0 || messages.length > 0) {
+          resolve(messages);
+        } else {
+          reject(new Error(`Claude CLI exited with code ${code}`));
+        }
+      });
+    });
+  }
+
+  /**
+   * Build CLI arguments for the claude command
+   */
+  private buildCliArgs(prompt: string, options: ClaudeSessionOptions): string[] {
+    const args: string[] = [
+      '--print',
+      '--output-format', 'stream-json',
+    ];
+
+    if (options.verbose) {
+      args.push('--verbose');
+    }
+
+    if (options.model) {
+      args.push('--model', options.model);
+    }
+
+    if (options.maxTurns) {
+      args.push('--max-turns', options.maxTurns.toString());
+    }
+
+    if (options.allowedTools && options.allowedTools.length > 0) {
+      args.push('--allowedTools', options.allowedTools.join(','));
+    }
+
+    if (options.resume) {
+      args.push('--resume', options.resume);
+    }
+
+    // Add the prompt as positional argument
+    args.push('--', prompt);
+
+    return args;
   }
 
   /**
@@ -216,25 +332,18 @@ Use:
       case 'issue_creation':
         return [...baseTools]; // Read-only + Bash for gh
       case 'planning':
-        return [...baseTools]; // Read-only exploration
+        return [...baseTools, 'Task']; // Add Task for Plan agent
       case 'implementation':
       case 'modification':
-        return [...baseTools, 'Edit', 'Write']; // Full write access
+        return [...baseTools, 'Edit', 'Write', 'Task']; // Full write access
     }
   }
 
   /**
-   * Generate a unique session ID
+   * Generate a unique session ID (fallback if not provided by CLI)
    */
   private generateSessionId(): string {
     return `${Date.now().toString(36)}${Math.random().toString(36).substring(2, 9)}`;
-  }
-
-  /**
-   * Get the prompt that was used for a session (for debugging)
-   */
-  getPromptForSession(purpose: SessionPurpose, params: SessionParams): string {
-    return this.buildPrompt(purpose, params);
   }
 }
 

--- a/plugins/idea-flow/src/errors.ts
+++ b/plugins/idea-flow/src/errors.ts
@@ -1,0 +1,107 @@
+/**
+ * Error handling for Idea Flow plugin
+ * Typed errors with recovery strategies
+ */
+
+import type { ErrorCode, RecoveryStrategy } from './types.js';
+
+export class IdeaFlowError extends Error {
+  constructor(
+    message: string,
+    public code: ErrorCode,
+    public ideaId?: string,
+    public recoverable: boolean = true
+  ) {
+    super(message);
+    this.name = 'IdeaFlowError';
+  }
+
+  toUserMessage(): string {
+    const strategy = recoveryStrategies[this.code];
+    return `${this.message}\n\nSuggestion: ${strategy.message}`;
+  }
+}
+
+/**
+ * Recovery strategies per error type
+ */
+export const recoveryStrategies: Record<ErrorCode, RecoveryStrategy> = {
+  IDEA_NOT_FOUND: {
+    action: 'list_ideas',
+    message: 'Use idea_list to see available ideas',
+  },
+  INVALID_STATE_TRANSITION: {
+    action: 'check_status',
+    message: 'Check idea status with idea_status first',
+  },
+  GITHUB_ERROR: {
+    action: 'retry',
+    message: 'GitHub API error, retry in a moment',
+  },
+  CLAUDE_CODE_SESSION_FAILED: {
+    action: 'resume_or_restart',
+    message: 'Session failed, can retry',
+  },
+  RATE_LIMIT_EXCEEDED: {
+    action: 'wait',
+    message: 'Rate limited, try again later',
+  },
+  NO_ISSUE_EXISTS: {
+    action: 'create_issue',
+    message: 'Create a GitHub issue first with idea_to_issue',
+  },
+  NO_PLAN_EXISTS: {
+    action: 'create_plan',
+    message: 'Generate a plan first with idea_plan, or pass skipPlan: true',
+  },
+  CONFIGURATION_ERROR: {
+    action: 'check_config',
+    message: 'Check plugin configuration',
+  },
+};
+
+/**
+ * Helper to create typed errors
+ */
+export function createError(
+  code: ErrorCode,
+  message?: string,
+  ideaId?: string
+): IdeaFlowError {
+  const defaultMessages: Record<ErrorCode, string> = {
+    IDEA_NOT_FOUND: 'Idea not found',
+    INVALID_STATE_TRANSITION: 'Cannot perform this action in current state',
+    GITHUB_ERROR: 'GitHub API error',
+    CLAUDE_CODE_SESSION_FAILED: 'Claude Code session failed',
+    RATE_LIMIT_EXCEEDED: 'Rate limit exceeded',
+    NO_ISSUE_EXISTS: 'No GitHub issue exists for this idea',
+    NO_PLAN_EXISTS: 'No implementation plan exists for this idea',
+    CONFIGURATION_ERROR: 'Plugin configuration error',
+  };
+
+  return new IdeaFlowError(
+    message || defaultMessages[code],
+    code,
+    ideaId
+  );
+}
+
+/**
+ * Check if error is recoverable
+ */
+export function isRecoverable(error: unknown): boolean {
+  if (error instanceof IdeaFlowError) {
+    return error.recoverable;
+  }
+  return false;
+}
+
+/**
+ * Get recovery suggestion for an error
+ */
+export function getRecoverySuggestion(error: unknown): string | null {
+  if (error instanceof IdeaFlowError) {
+    return recoveryStrategies[error.code]?.message || null;
+  }
+  return null;
+}

--- a/plugins/idea-flow/src/notifications.ts
+++ b/plugins/idea-flow/src/notifications.ts
@@ -1,0 +1,224 @@
+/**
+ * Notification management for Idea Flow plugin
+ * Handles user notifications when Claude Code tasks complete
+ */
+
+import type {
+  PluginConfig,
+  Notification,
+  NotificationType,
+} from './types.js';
+import type { StateManager } from './state.js';
+
+export interface NotificationPayload {
+  type: NotificationType;
+  ideaId: string;
+  title: string;
+  message: string;
+  issueUrl?: string;
+  prUrl?: string;
+  commentUrl?: string;
+  error?: string;
+}
+
+export class NotificationManager {
+  private config: PluginConfig;
+  private state: StateManager;
+
+  constructor(config: PluginConfig, state: StateManager) {
+    this.config = config;
+    this.state = state;
+  }
+
+  /**
+   * Send a notification to the user
+   */
+  async notify(payload: NotificationPayload): Promise<Notification> {
+    // Store notification in state
+    const notification = this.state.addNotification(
+      payload.type,
+      payload.ideaId,
+      payload.title,
+      payload.message,
+      {
+        issueUrl: payload.issueUrl,
+        prUrl: payload.prUrl,
+        commentUrl: payload.commentUrl,
+        error: payload.error,
+      }
+    );
+
+    // If auto-notify is enabled, log for immediate delivery
+    // In a real implementation, this would trigger OpenClaw's notification system
+    if (this.config.autoNotify) {
+      console.log(`[NOTIFICATION] ${payload.type}: ${payload.message}`);
+    }
+
+    return notification;
+  }
+
+  /**
+   * Create notification for issue creation
+   */
+  async notifyIssueCreated(
+    ideaId: string,
+    title: string,
+    issueUrl: string
+  ): Promise<Notification> {
+    return this.notify({
+      type: 'issue_created',
+      ideaId,
+      title,
+      message: `GitHub issue created for "${title}".\n\nReview at: ${issueUrl}\n\nYou can now:\n- Plan: "plan the implementation"\n- Implement: "implement this idea"\n- Modify: "change the issue to..."\n- Delete: "delete this idea"`,
+      issueUrl,
+    });
+  }
+
+  /**
+   * Create notification for plan completion
+   */
+  async notifyPlanReady(
+    ideaId: string,
+    title: string,
+    issueUrl: string,
+    commentUrl: string
+  ): Promise<Notification> {
+    return this.notify({
+      type: 'plan_ready',
+      ideaId,
+      title,
+      message: `Implementation plan ready for "${title}".\n\nPlan posted at: ${commentUrl}\n\nTo proceed, say "implement this idea" or request modifications.`,
+      issueUrl,
+      commentUrl,
+    });
+  }
+
+  /**
+   * Create notification for implementation completion
+   */
+  async notifyImplementationReady(
+    ideaId: string,
+    title: string,
+    prUrl: string
+  ): Promise<Notification> {
+    return this.notify({
+      type: 'implementation_ready',
+      ideaId,
+      title,
+      message: `Implementation complete for "${title}"!\n\nPull Request: ${prUrl}\n\nReview the PR and request modifications if needed.`,
+      prUrl,
+    });
+  }
+
+  /**
+   * Create notification for modification completion
+   */
+  async notifyModificationComplete(
+    ideaId: string,
+    title: string,
+    target: 'issue' | 'plan' | 'implementation'
+  ): Promise<Notification> {
+    return this.notify({
+      type: 'modification_complete',
+      ideaId,
+      title,
+      message: `Modifications applied to ${target} for "${title}".`,
+    });
+  }
+
+  /**
+   * Create notification for errors
+   */
+  async notifyError(
+    ideaId: string,
+    title: string,
+    error: string
+  ): Promise<Notification> {
+    return this.notify({
+      type: 'error',
+      ideaId,
+      title,
+      message: `Error processing "${title}": ${error}`,
+      error,
+    });
+  }
+
+  /**
+   * Get all unread notifications
+   */
+  getUnread(): Notification[] {
+    return this.state.getUnreadNotifications();
+  }
+
+  /**
+   * Get notifications for a specific idea
+   */
+  getForIdea(ideaId: string): Notification[] {
+    return this.state.getNotificationsForIdea(ideaId);
+  }
+
+  /**
+   * Mark notification as read
+   */
+  markRead(notificationId: string): void {
+    this.state.markNotificationRead(notificationId);
+  }
+
+  /**
+   * Mark all notifications as read
+   */
+  markAllRead(ideaId?: string): void {
+    this.state.markAllNotificationsRead(ideaId);
+  }
+
+  /**
+   * Clear notifications
+   */
+  clear(ideaId?: string): void {
+    this.state.clearNotifications(ideaId);
+  }
+
+  /**
+   * Format notifications for display
+   */
+  formatNotifications(notifications: Notification[]): string {
+    if (notifications.length === 0) {
+      return 'No notifications.';
+    }
+
+    return notifications
+      .map((n, i) => {
+        const icon = this.getNotificationIcon(n.type);
+        const readStatus = n.read ? '' : ' [NEW]';
+        return `${i + 1}. ${icon} ${n.title}${readStatus}\n   ${n.message.split('\n')[0]}`;
+      })
+      .join('\n\n');
+  }
+
+  private getNotificationIcon(type: NotificationType): string {
+    switch (type) {
+      case 'issue_created':
+        return '[Issue]';
+      case 'plan_ready':
+        return '[Plan]';
+      case 'implementation_ready':
+        return '[PR]';
+      case 'modification_complete':
+        return '[Modified]';
+      case 'error':
+        return '[Error]';
+      default:
+        return '[Info]';
+    }
+  }
+}
+
+/**
+ * Create a notification manager instance
+ */
+export function createNotificationManager(
+  config: PluginConfig,
+  state: StateManager
+): NotificationManager {
+  return new NotificationManager(config, state);
+}

--- a/plugins/idea-flow/src/state.ts
+++ b/plugins/idea-flow/src/state.ts
@@ -1,0 +1,333 @@
+/**
+ * State management for Idea Flow plugin
+ * Handles persistent state across sessions
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  PluginState,
+  Idea,
+  IdeaStatus,
+  Notification,
+  NotificationType,
+  ClarificationEntry,
+  SessionRecord,
+  ImplementationPlan,
+  GitHubArtifacts,
+} from './types.js';
+
+export class StateManager {
+  private statePath: string;
+  private stateFilePath: string;
+  private state: PluginState;
+
+  constructor(statePath: string) {
+    // Expand ~ to home directory
+    this.statePath = statePath.replace(/^~/, process.env.HOME || '');
+    this.stateFilePath = path.join(this.statePath, 'state.json');
+    this.state = this.loadState();
+  }
+
+  private getDefaultState(): PluginState {
+    return {
+      ideas: {},
+      notifications: [],
+      lastUpdatedAt: null,
+    };
+  }
+
+  private loadState(): PluginState {
+    try {
+      // Ensure directory exists
+      if (!fs.existsSync(this.statePath)) {
+        fs.mkdirSync(this.statePath, { recursive: true });
+      }
+
+      if (fs.existsSync(this.stateFilePath)) {
+        const content = fs.readFileSync(this.stateFilePath, 'utf-8');
+        const parsed = JSON.parse(content) as Partial<PluginState>;
+
+        // Merge with defaults to ensure all fields exist
+        return {
+          ...this.getDefaultState(),
+          ...parsed,
+        };
+      }
+    } catch (error) {
+      console.error('Error loading state file:', error);
+    }
+
+    return this.getDefaultState();
+  }
+
+  private saveState(): void {
+    try {
+      // Ensure directory exists
+      if (!fs.existsSync(this.statePath)) {
+        fs.mkdirSync(this.statePath, { recursive: true });
+      }
+
+      this.state.lastUpdatedAt = new Date().toISOString();
+
+      fs.writeFileSync(
+        this.stateFilePath,
+        JSON.stringify(this.state, null, 2),
+        'utf-8'
+      );
+    } catch (error) {
+      console.error('Error saving state file:', error);
+      throw error;
+    }
+  }
+
+  // ============================================================================
+  // Idea Management
+  // ============================================================================
+
+  getIdea(ideaId: string): Idea | null {
+    return this.state.ideas[ideaId] ?? null;
+  }
+
+  getAllIdeas(): Idea[] {
+    return Object.values(this.state.ideas);
+  }
+
+  getIdeasByStatus(status: IdeaStatus): Idea[] {
+    return this.getAllIdeas().filter(idea => idea.status === status);
+  }
+
+  saveIdea(idea: Idea): void {
+    idea.updatedAt = new Date().toISOString();
+    this.state.ideas[idea.id] = idea;
+    this.saveState();
+  }
+
+  deleteIdea(ideaId: string): boolean {
+    if (this.state.ideas[ideaId]) {
+      delete this.state.ideas[ideaId];
+      this.saveState();
+      return true;
+    }
+    return false;
+  }
+
+  createIdea(
+    id: string,
+    title: string,
+    description: string,
+    repo: string
+  ): Idea {
+    const now = new Date().toISOString();
+    const idea: Idea = {
+      id,
+      title,
+      description,
+      status: 'draft',
+      createdAt: now,
+      updatedAt: now,
+      clarificationHistory: [],
+      github: { repo },
+      sessions: [],
+    };
+    this.saveIdea(idea);
+    return idea;
+  }
+
+  updateIdeaStatus(ideaId: string, status: IdeaStatus): void {
+    const idea = this.getIdea(ideaId);
+    if (idea) {
+      idea.status = status;
+      this.saveIdea(idea);
+    }
+  }
+
+  // ============================================================================
+  // Clarification Management
+  // ============================================================================
+
+  addClarification(
+    ideaId: string,
+    question: string,
+    answer: string,
+    updateDescription: boolean = true
+  ): void {
+    const idea = this.getIdea(ideaId);
+    if (!idea) return;
+
+    idea.clarificationHistory.push({
+      question,
+      answer,
+      askedAt: new Date().toISOString(),
+    });
+
+    if (updateDescription) {
+      idea.description = `${idea.description}\n\n**Clarification**: ${question}\n${answer}`;
+    }
+
+    idea.status = 'clarifying';
+    this.saveIdea(idea);
+  }
+
+  // ============================================================================
+  // GitHub Artifacts Management
+  // ============================================================================
+
+  updateGitHubArtifacts(ideaId: string, artifacts: Partial<GitHubArtifacts>): void {
+    const idea = this.getIdea(ideaId);
+    if (!idea) return;
+
+    idea.github = {
+      ...idea.github,
+      ...artifacts,
+    } as GitHubArtifacts;
+    this.saveIdea(idea);
+  }
+
+  // ============================================================================
+  // Session Management
+  // ============================================================================
+
+  addSession(ideaId: string, session: SessionRecord): void {
+    const idea = this.getIdea(ideaId);
+    if (!idea) return;
+
+    idea.sessions.push(session);
+    this.saveIdea(idea);
+  }
+
+  updateSessionStatus(
+    ideaId: string,
+    sessionId: string,
+    status: SessionRecord['status'],
+    error?: string
+  ): void {
+    const idea = this.getIdea(ideaId);
+    if (!idea) return;
+
+    const session = idea.sessions.find(s => s.sessionId === sessionId);
+    if (session) {
+      session.status = status;
+      session.completedAt = new Date().toISOString();
+      if (error) {
+        session.error = error;
+      }
+      this.saveIdea(idea);
+    }
+  }
+
+  getLastSession(ideaId: string, purpose?: SessionRecord['purpose']): SessionRecord | null {
+    const idea = this.getIdea(ideaId);
+    if (!idea) return null;
+
+    const sessions = purpose
+      ? idea.sessions.filter(s => s.purpose === purpose)
+      : idea.sessions;
+
+    return sessions[sessions.length - 1] ?? null;
+  }
+
+  // ============================================================================
+  // Plan Management
+  // ============================================================================
+
+  updatePlan(ideaId: string, plan: ImplementationPlan): void {
+    const idea = this.getIdea(ideaId);
+    if (!idea) return;
+
+    idea.plan = plan;
+    this.saveIdea(idea);
+  }
+
+  // ============================================================================
+  // Notification Management
+  // ============================================================================
+
+  addNotification(
+    type: NotificationType,
+    ideaId: string,
+    title: string,
+    message: string,
+    extras?: {
+      issueUrl?: string;
+      prUrl?: string;
+      commentUrl?: string;
+      error?: string;
+    }
+  ): Notification {
+    const notification: Notification = {
+      id: this.generateId(),
+      type,
+      ideaId,
+      title,
+      message,
+      createdAt: new Date().toISOString(),
+      read: false,
+      ...extras,
+    };
+
+    this.state.notifications.push(notification);
+    this.saveState();
+    return notification;
+  }
+
+  getUnreadNotifications(): Notification[] {
+    return this.state.notifications.filter(n => !n.read);
+  }
+
+  getNotificationsForIdea(ideaId: string): Notification[] {
+    return this.state.notifications.filter(n => n.ideaId === ideaId);
+  }
+
+  markNotificationRead(notificationId: string): void {
+    const notification = this.state.notifications.find(n => n.id === notificationId);
+    if (notification) {
+      notification.read = true;
+      this.saveState();
+    }
+  }
+
+  markAllNotificationsRead(ideaId?: string): void {
+    for (const notification of this.state.notifications) {
+      if (!ideaId || notification.ideaId === ideaId) {
+        notification.read = true;
+      }
+    }
+    this.saveState();
+  }
+
+  clearNotifications(ideaId?: string): void {
+    if (ideaId) {
+      this.state.notifications = this.state.notifications.filter(
+        n => n.ideaId !== ideaId
+      );
+    } else {
+      this.state.notifications = [];
+    }
+    this.saveState();
+  }
+
+  // ============================================================================
+  // Utility
+  // ============================================================================
+
+  generateId(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  getFullState(): PluginState {
+    return { ...this.state };
+  }
+
+  resetState(): void {
+    this.state = this.getDefaultState();
+    this.saveState();
+  }
+}
+
+/**
+ * Create a state manager instance
+ */
+export function createStateManager(statePath: string = '~/.idea-flow'): StateManager {
+  return new StateManager(statePath);
+}

--- a/plugins/idea-flow/src/tools/capture.ts
+++ b/plugins/idea-flow/src/tools/capture.ts
@@ -1,0 +1,59 @@
+/**
+ * idea_capture tool
+ * Start capturing a new idea
+ */
+
+import type { StateManager } from '../state.js';
+import type { PluginConfig, CaptureIdeaInput, CaptureIdeaOutput } from '../types.js';
+
+export const ideaCaptureDefinition = {
+  name: 'idea_capture',
+  description: 'Start capturing a new idea. Returns an idea ID for tracking.',
+  parameters: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        description: 'Short title for the idea (2-10 words)',
+      },
+      description: {
+        type: 'string',
+        description: 'Initial description of what the user wants',
+      },
+      repo: {
+        type: 'string',
+        description: 'Target repository (owner/repo). Uses default if not provided.',
+      },
+    },
+    required: ['title', 'description'],
+  },
+};
+
+export async function captureIdea(
+  state: StateManager,
+  config: PluginConfig,
+  params: CaptureIdeaInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: CaptureIdeaOutput }> {
+  const ideaId = state.generateId();
+  const repo = params.repo || config.defaultRepo;
+
+  const idea = state.createIdea(ideaId, params.title, params.description, repo);
+
+  const text = [
+    `Idea captured: "${params.title}" [${ideaId.slice(0, 8)}]`,
+    '',
+    `Repository: ${repo}`,
+    '',
+    'To refine this idea, ask clarifying questions using idea_clarify.',
+    'When ready, use idea_to_issue to create a GitHub issue.',
+  ].join('\n');
+
+  return {
+    content: [{ type: 'text', text }],
+    details: {
+      ideaId,
+      status: idea.status,
+      title: params.title,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/clarify.ts
+++ b/plugins/idea-flow/src/tools/clarify.ts
@@ -1,0 +1,67 @@
+/**
+ * idea_clarify tool
+ * Record a clarifying question and answer for an idea
+ */
+
+import type { StateManager } from '../state.js';
+import type { ClarifyIdeaInput, ClarifyIdeaOutput } from '../types.js';
+import { createError } from '../errors.js';
+
+export const ideaClarifyDefinition = {
+  name: 'idea_clarify',
+  description: 'Record a clarifying question and answer for an idea',
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+      question: {
+        type: 'string',
+        description: 'The clarifying question asked',
+      },
+      answer: {
+        type: 'string',
+        description: "The user's answer",
+      },
+      updateDescription: {
+        type: 'boolean',
+        description: 'Whether to incorporate this into the description (default: true)',
+      },
+    },
+    required: ['ideaId', 'question', 'answer'],
+  },
+};
+
+export async function clarifyIdea(
+  state: StateManager,
+  params: ClarifyIdeaInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: ClarifyIdeaOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  const updateDescription = params.updateDescription !== false;
+  state.addClarification(params.ideaId, params.question, params.answer, updateDescription);
+
+  // Refresh idea to get updated clarification count
+  const updatedIdea = state.getIdea(params.ideaId)!;
+
+  const text = [
+    `Clarification recorded for "${idea.title}".`,
+    '',
+    `Total clarifications: ${updatedIdea.clarificationHistory.length}`,
+    '',
+    'Continue asking questions or use idea_to_issue when ready.',
+  ].join('\n');
+
+  return {
+    content: [{ type: 'text', text }],
+    details: {
+      ideaId: idea.id,
+      clarificationCount: updatedIdea.clarificationHistory.length,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/delete.ts
+++ b/plugins/idea-flow/src/tools/delete.ts
@@ -1,0 +1,101 @@
+/**
+ * idea_delete tool
+ * Delete an idea and optionally close associated GitHub artifacts
+ */
+
+import type { StateManager } from '../state.js';
+import type { NotificationManager } from '../notifications.js';
+import type { DeleteIdeaInput, DeleteIdeaOutput } from '../types.js';
+import { createError } from '../errors.js';
+
+export const ideaDeleteDefinition = {
+  name: 'idea_delete',
+  description: 'Delete an idea and optionally close associated GitHub artifacts',
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+      closeIssue: {
+        type: 'boolean',
+        description: 'Also close the GitHub issue if it exists',
+      },
+      closePR: {
+        type: 'boolean',
+        description: 'Also close the GitHub PR if it exists',
+      },
+    },
+    required: ['ideaId'],
+  },
+};
+
+export async function deleteIdea(
+  state: StateManager,
+  notificationManager: NotificationManager,
+  params: DeleteIdeaInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: DeleteIdeaOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  const result: DeleteIdeaOutput = {
+    ideaId: idea.id,
+    deleted: false,
+    issueClosed: false,
+    prClosed: false,
+  };
+
+  const actions: string[] = [];
+
+  // Note: In production, this would use gh CLI to close issues/PRs
+  // For now, we just track the intent and provide the commands
+
+  if (params.closeIssue && idea.github?.issueNumber) {
+    // In production: await exec(`gh issue close ${idea.github.issueNumber} --repo ${idea.github.repo}`)
+    result.issueClosed = true;
+    actions.push(`Close issue #${idea.github.issueNumber}: gh issue close ${idea.github.issueNumber} --repo ${idea.github.repo}`);
+  }
+
+  if (params.closePR && idea.github?.prNumber) {
+    // In production: await exec(`gh pr close ${idea.github.prNumber} --repo ${idea.github.repo}`)
+    result.prClosed = true;
+    actions.push(`Close PR #${idea.github.prNumber}: gh pr close ${idea.github.prNumber} --repo ${idea.github.repo}`);
+  }
+
+  // Clear notifications for this idea
+  notificationManager.clear(params.ideaId);
+
+  // Delete the idea from state
+  state.deleteIdea(params.ideaId);
+  result.deleted = true;
+
+  const text = [
+    `Idea "${idea.title}" [${idea.id.slice(0, 8)}] has been deleted.`,
+    '',
+  ];
+
+  if (actions.length > 0) {
+    text.push('GitHub actions to perform:');
+    text.push(...actions.map((a) => `- ${a}`));
+    text.push('');
+    text.push('Note: Run these commands to close the GitHub artifacts.');
+  } else if (idea.github?.issueNumber || idea.github?.prNumber) {
+    text.push('GitHub artifacts were NOT closed:');
+    if (idea.github.issueNumber) {
+      text.push(`- Issue #${idea.github.issueNumber} remains open`);
+    }
+    if (idea.github.prNumber) {
+      text.push(`- PR #${idea.github.prNumber} remains open`);
+    }
+    text.push('');
+    text.push('Use closeIssue: true and/or closePR: true to close them.');
+  }
+
+  return {
+    content: [{ type: 'text', text: text.join('\n') }],
+    details: result,
+  };
+}

--- a/plugins/idea-flow/src/tools/history.ts
+++ b/plugins/idea-flow/src/tools/history.ts
@@ -1,0 +1,128 @@
+/**
+ * idea_history tool
+ * View full history of an idea including clarifications and sessions
+ */
+
+import type { StateManager } from '../state.js';
+import type { GetIdeaHistoryInput, GetIdeaHistoryOutput } from '../types.js';
+import { createError } from '../errors.js';
+
+export const ideaHistoryDefinition = {
+  name: 'idea_history',
+  description: 'View full history of an idea including clarifications and sessions',
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+    },
+    required: ['ideaId'],
+  },
+};
+
+export async function getIdeaHistory(
+  state: StateManager,
+  params: GetIdeaHistoryInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: GetIdeaHistoryOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  const lines = [
+    `History for: "${idea.title}" [${idea.id.slice(0, 8)}]`,
+    '',
+    'Timeline:',
+    `- Created: ${new Date(idea.createdAt).toLocaleString()}`,
+    `- Last updated: ${new Date(idea.updatedAt).toLocaleString()}`,
+    '',
+  ];
+
+  // Clarification history
+  if (idea.clarificationHistory.length > 0) {
+    lines.push('Clarifications:');
+    for (const c of idea.clarificationHistory) {
+      lines.push(`[${new Date(c.askedAt).toLocaleString()}]`);
+      lines.push(`  Q: ${c.question}`);
+      lines.push(`  A: ${c.answer}`);
+      lines.push('');
+    }
+  } else {
+    lines.push('Clarifications: None');
+    lines.push('');
+  }
+
+  // Session history
+  if (idea.sessions.length > 0) {
+    lines.push('Claude Code Sessions:');
+    for (const s of idea.sessions) {
+      const duration = s.completedAt
+        ? ` (${Math.round((new Date(s.completedAt).getTime() - new Date(s.startedAt).getTime()) / 1000)}s)`
+        : '';
+      lines.push(`[${new Date(s.startedAt).toLocaleString()}] ${s.purpose} - ${s.status}${duration}`);
+      if (s.claudeCodeUrl) {
+        lines.push(`  URL: ${s.claudeCodeUrl}`);
+      }
+      if (s.error) {
+        lines.push(`  Error: ${s.error}`);
+      }
+    }
+    lines.push('');
+  } else {
+    lines.push('Claude Code Sessions: None');
+    lines.push('');
+  }
+
+  // GitHub artifacts
+  if (idea.github) {
+    lines.push('GitHub Artifacts:');
+    lines.push(`  Repository: ${idea.github.repo}`);
+    if (idea.github.issueNumber) {
+      lines.push(`  Issue #${idea.github.issueNumber}: ${idea.github.issueUrl}`);
+    }
+    if (idea.github.prNumber) {
+      lines.push(`  PR #${idea.github.prNumber}: ${idea.github.prUrl}`);
+    }
+    if (idea.github.branch) {
+      lines.push(`  Branch: ${idea.github.branch}`);
+    }
+    lines.push('');
+  }
+
+  // Plan details
+  if (idea.plan) {
+    lines.push('Implementation Plan:');
+    lines.push(`  Summary: ${idea.plan.summary}`);
+    lines.push(`  Complexity: ${idea.plan.estimatedComplexity}`);
+    lines.push(`  Steps: ${idea.plan.steps.length}`);
+    for (const step of idea.plan.steps) {
+      lines.push(`    ${step.order}. ${step.description}`);
+    }
+    if (idea.plan.criticalFiles.length > 0) {
+      lines.push(`  Critical files:`);
+      for (const file of idea.plan.criticalFiles) {
+        lines.push(`    - ${file.path}: ${file.reason}`);
+      }
+    }
+    if (idea.plan.risks.length > 0) {
+      lines.push(`  Risks:`);
+      for (const risk of idea.plan.risks) {
+        lines.push(`    - ${risk}`);
+      }
+    }
+    if (idea.plan.commentUrl) {
+      lines.push(`  Posted at: ${idea.plan.commentUrl}`);
+    }
+  }
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+    details: {
+      idea,
+      clarifications: idea.clarificationHistory,
+      sessions: idea.sessions,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/implement.ts
+++ b/plugins/idea-flow/src/tools/implement.ts
@@ -1,0 +1,163 @@
+/**
+ * idea_implement tool
+ * Implement the idea using Claude Code, creating a PR
+ */
+
+import type { StateManager } from '../state.js';
+import type { ClaudeCodeSessionManager } from '../claude-code/session-manager.js';
+import type { NotificationManager } from '../notifications.js';
+import type { PluginConfig, ImplementIdeaInput, ImplementIdeaOutput } from '../types.js';
+import { createError } from '../errors.js';
+import { parseSessionOutput } from '../claude-code/parsers.js';
+
+export const ideaImplementDefinition = {
+  name: 'idea_implement',
+  description: 'Implement the idea using Claude Code, creating a PR',
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+      skipPlan: {
+        type: 'boolean',
+        description: 'Skip planning phase if no plan exists',
+      },
+    },
+    required: ['ideaId'],
+  },
+};
+
+export async function implementIdea(
+  state: StateManager,
+  sessionManager: ClaudeCodeSessionManager,
+  notificationManager: NotificationManager,
+  config: PluginConfig,
+  params: ImplementIdeaInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: ImplementIdeaOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  if (!idea.github?.issueNumber) {
+    throw createError(
+      'NO_ISSUE_EXISTS',
+      'No GitHub issue exists for this idea. Create one first with idea_to_issue.',
+      params.ideaId
+    );
+  }
+
+  // Enforce planning before implementation unless explicitly skipped
+  if (!idea.plan && !params.skipPlan && config.requirePlanBeforeImplement) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            'No implementation plan exists for this idea.',
+            '',
+            'Options:',
+            '1. Generate a plan first with idea_plan (recommended)',
+            '2. Pass skipPlan: true to implement without a plan',
+            '',
+            'Planning helps ensure a well-structured implementation.',
+          ].join('\n'),
+        },
+      ],
+      details: {
+        ideaId: idea.id,
+      },
+    };
+  }
+
+  // Update status
+  state.updateIdeaStatus(params.ideaId, 'implementing');
+
+  // Start implementation session
+  const result = await sessionManager.startSession('implementation', {
+    repo: idea.github.repo,
+    issueNumber: idea.github.issueNumber,
+    issueUrl: idea.github.issueUrl!,
+    plan: idea.plan,
+  });
+
+  // Record session
+  state.addSession(params.ideaId, {
+    sessionId: result.sessionId,
+    purpose: 'implementation',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    claudeCodeUrl: result.claudeCodeUrl,
+  });
+
+  // Parse PR info from output
+  const parsed = parseSessionOutput(result.messages);
+
+  if (parsed.prUrl && parsed.prNumber) {
+    // Update GitHub artifacts
+    state.updateGitHubArtifacts(params.ideaId, {
+      prNumber: parsed.prNumber,
+      prUrl: parsed.prUrl,
+      branch: parsed.branch ?? undefined,
+    });
+
+    // Update status
+    state.updateIdeaStatus(params.ideaId, 'implemented');
+    state.updateSessionStatus(params.ideaId, result.sessionId, 'completed');
+
+    // Notify user
+    await notificationManager.notifyImplementationReady(params.ideaId, idea.title, parsed.prUrl);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            `Pull request created: ${parsed.prUrl}`,
+            '',
+            parsed.branch ? `Branch: ${parsed.branch}` : '',
+            '',
+            'Review the PR and request modifications if needed.',
+          ]
+            .filter(Boolean)
+            .join('\n'),
+        },
+      ],
+      details: {
+        ideaId: idea.id,
+        sessionId: result.sessionId,
+        prUrl: parsed.prUrl,
+        prNumber: parsed.prNumber,
+        branch: parsed.branch ?? undefined,
+      },
+    };
+  }
+
+  // Session started but PR not yet created (async)
+  return {
+    content: [
+      {
+        type: 'text',
+        text: [
+          'Claude Code session started for implementation.',
+          '',
+          `Session URL: ${result.claudeCodeUrl}`,
+          '',
+          'Claude Code is:',
+          '1. Creating a feature branch',
+          '2. Implementing the changes',
+          '3. Running tests',
+          '4. Creating a pull request',
+          '',
+          'Check idea_status for updates when the session completes.',
+        ].join('\n'),
+      },
+    ],
+    details: {
+      ideaId: idea.id,
+      sessionId: result.sessionId,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/index.ts
+++ b/plugins/idea-flow/src/tools/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Tool exports for Idea Flow plugin
+ */
+
+// Tool definitions
+export { ideaCaptureDefinition } from './capture.js';
+export { ideaClarifyDefinition } from './clarify.js';
+export { ideaListDefinition } from './list.js';
+export { ideaStatusDefinition } from './status.js';
+export { ideaHistoryDefinition } from './history.js';
+export { ideaToIssueDefinition } from './to-issue.js';
+export { ideaPlanDefinition } from './plan.js';
+export { ideaImplementDefinition } from './implement.js';
+export { ideaModifyDefinition } from './modify.js';
+export { ideaDeleteDefinition } from './delete.js';
+
+// Tool implementations
+export { captureIdea } from './capture.js';
+export { clarifyIdea } from './clarify.js';
+export { listIdeas } from './list.js';
+export { getIdeaStatus } from './status.js';
+export { getIdeaHistory } from './history.js';
+export { ideaToIssue } from './to-issue.js';
+export { planIdea } from './plan.js';
+export { implementIdea } from './implement.js';
+export { modifyIdea } from './modify.js';
+export { deleteIdea } from './delete.js';

--- a/plugins/idea-flow/src/tools/list.ts
+++ b/plugins/idea-flow/src/tools/list.ts
@@ -1,0 +1,107 @@
+/**
+ * idea_list tool
+ * List all ideas with their current status
+ */
+
+import type { StateManager } from '../state.js';
+import type { ListIdeasInput, ListIdeasOutput, IdeaSummary, Idea } from '../types.js';
+
+export const ideaListDefinition = {
+  name: 'idea_list',
+  description: 'List all ideas with their current status',
+  parameters: {
+    type: 'object',
+    properties: {
+      status: {
+        type: 'string',
+        enum: [
+          'draft',
+          'clarifying',
+          'issue_creating',
+          'issue_ready',
+          'planning',
+          'planned',
+          'implementing',
+          'implemented',
+          'completed',
+          'deleted',
+        ],
+        description: 'Filter by status',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of ideas to return',
+      },
+    },
+    required: [],
+  },
+};
+
+function ideaToSummary(idea: Idea): IdeaSummary {
+  return {
+    id: idea.id,
+    title: idea.title,
+    status: idea.status,
+    createdAt: idea.createdAt,
+    updatedAt: idea.updatedAt,
+    hasIssue: !!idea.github?.issueNumber,
+    hasPlan: !!idea.plan,
+    hasPR: !!idea.github?.prNumber,
+  };
+}
+
+export async function listIdeas(
+  state: StateManager,
+  params: ListIdeasInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: ListIdeasOutput }> {
+  let ideas = params.status
+    ? state.getIdeasByStatus(params.status)
+    : state.getAllIdeas();
+
+  // Sort by most recently updated
+  ideas = ideas.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  );
+
+  const totalCount = ideas.length;
+
+  // Apply limit
+  if (params.limit && params.limit > 0) {
+    ideas = ideas.slice(0, params.limit);
+  }
+
+  const summaries = ideas.map(ideaToSummary);
+
+  if (summaries.length === 0) {
+    const statusFilter = params.status ? ` with status "${params.status}"` : '';
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `No ideas found${statusFilter}.\n\nUse idea_capture to start a new idea.`,
+        },
+      ],
+      details: { ideas: [], totalCount: 0 },
+    };
+  }
+
+  const lines = [
+    `Found ${totalCount} idea(s):`,
+    '',
+    ...summaries.map((s) => {
+      const indicators = [];
+      if (s.hasIssue) indicators.push('Issue');
+      if (s.hasPlan) indicators.push('Plan');
+      if (s.hasPR) indicators.push('PR');
+      const indicatorStr = indicators.length > 0 ? ` [${indicators.join(', ')}]` : '';
+      return `- [${s.id.slice(0, 8)}] "${s.title}" (${s.status})${indicatorStr}`;
+    }),
+    '',
+    'Use idea_status <ideaId> for details.',
+  ];
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+    details: { ideas: summaries, totalCount },
+  };
+}

--- a/plugins/idea-flow/src/tools/modify.ts
+++ b/plugins/idea-flow/src/tools/modify.ts
@@ -1,0 +1,167 @@
+/**
+ * idea_modify tool
+ * Request modifications to an idea's issue, plan, or implementation
+ */
+
+import type { StateManager } from '../state.js';
+import type { ClaudeCodeSessionManager } from '../claude-code/session-manager.js';
+import type { NotificationManager } from '../notifications.js';
+import type { ModifyIdeaInput, ModifyIdeaOutput } from '../types.js';
+import { createError } from '../errors.js';
+import { parseSessionOutput } from '../claude-code/parsers.js';
+
+export const ideaModifyDefinition = {
+  name: 'idea_modify',
+  description: "Request modifications to an idea's issue, plan, or implementation",
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+      modificationRequest: {
+        type: 'string',
+        description: 'Description of the modifications to make',
+      },
+      target: {
+        type: 'string',
+        enum: ['issue', 'plan', 'implementation'],
+        description: 'What to modify: issue, plan, or implementation',
+      },
+    },
+    required: ['ideaId', 'modificationRequest', 'target'],
+  },
+};
+
+export async function modifyIdea(
+  state: StateManager,
+  sessionManager: ClaudeCodeSessionManager,
+  notificationManager: NotificationManager,
+  params: ModifyIdeaInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: ModifyIdeaOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  // Validate target exists
+  switch (params.target) {
+    case 'issue':
+      if (!idea.github?.issueNumber) {
+        throw createError(
+          'NO_ISSUE_EXISTS',
+          'No GitHub issue exists for this idea.',
+          params.ideaId
+        );
+      }
+      break;
+    case 'plan':
+      if (!idea.plan) {
+        throw createError(
+          'NO_PLAN_EXISTS',
+          'No implementation plan exists for this idea.',
+          params.ideaId
+        );
+      }
+      break;
+    case 'implementation':
+      if (!idea.github?.prNumber) {
+        throw createError(
+          'NO_ISSUE_EXISTS',
+          'No pull request exists for this idea.',
+          params.ideaId
+        );
+      }
+      break;
+  }
+
+  // Get the last session for this target to potentially resume
+  const lastSession = state.getLastSession(
+    params.ideaId,
+    params.target === 'issue' ? 'issue_creation' : params.target === 'plan' ? 'planning' : 'implementation'
+  );
+
+  // Start or resume modification session
+  let result;
+  if (lastSession && lastSession.status === 'completed') {
+    // Resume the previous session with modification request
+    result = await sessionManager.resumeSession(
+      lastSession.sessionId,
+      `Make the following modifications: ${params.modificationRequest}`,
+      true // fork the session
+    );
+  } else {
+    // Start new modification session
+    result = await sessionManager.startSession('modification', {
+      repo: idea.github!.repo,
+      issueNumber: idea.github?.issueNumber,
+      issueUrl: idea.github?.issueUrl,
+      modificationRequest: params.modificationRequest,
+    });
+  }
+
+  // Record session
+  state.addSession(params.ideaId, {
+    sessionId: result.sessionId,
+    purpose: 'modification',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    claudeCodeUrl: `https://claude.ai/code/session_${result.sessionId}`,
+  });
+
+  // Check if modifications were applied
+  const parsed = parseSessionOutput(result.messages);
+
+  if (parsed.success) {
+    state.updateSessionStatus(params.ideaId, result.sessionId, 'completed');
+    await notificationManager.notifyModificationComplete(params.ideaId, idea.title, params.target);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            `Modifications applied to ${params.target} for "${idea.title}".`,
+            '',
+            `Request: ${params.modificationRequest}`,
+            '',
+            'Check the updated artifacts:',
+            idea.github?.issueUrl ? `- Issue: ${idea.github.issueUrl}` : '',
+            idea.github?.prUrl ? `- PR: ${idea.github.prUrl}` : '',
+          ]
+            .filter(Boolean)
+            .join('\n'),
+        },
+      ],
+      details: {
+        ideaId: idea.id,
+        sessionId: result.sessionId,
+        success: true,
+      },
+    };
+  }
+
+  // Session started but modifications not yet complete (async)
+  return {
+    content: [
+      {
+        type: 'text',
+        text: [
+          `Claude Code session started for ${params.target} modifications.`,
+          '',
+          `Request: ${params.modificationRequest}`,
+          '',
+          `Session URL: https://claude.ai/code/session_${result.sessionId}`,
+          '',
+          'Check idea_status for updates when the session completes.',
+        ].join('\n'),
+      },
+    ],
+    details: {
+      ideaId: idea.id,
+      sessionId: result.sessionId,
+      success: false,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/plan.ts
+++ b/plugins/idea-flow/src/tools/plan.ts
@@ -1,0 +1,137 @@
+/**
+ * idea_plan tool
+ * Generate an implementation plan using Claude Code's Plan agent and post as comment
+ */
+
+import type { StateManager } from '../state.js';
+import type { ClaudeCodeSessionManager } from '../claude-code/session-manager.js';
+import type { NotificationManager } from '../notifications.js';
+import type { PlanIdeaInput, PlanIdeaOutput } from '../types.js';
+import { createError } from '../errors.js';
+import { parseSessionOutput } from '../claude-code/parsers.js';
+
+export const ideaPlanDefinition = {
+  name: 'idea_plan',
+  description: "Generate an implementation plan using Claude Code's Plan agent and post as comment",
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+    },
+    required: ['ideaId'],
+  },
+};
+
+export async function planIdea(
+  state: StateManager,
+  sessionManager: ClaudeCodeSessionManager,
+  notificationManager: NotificationManager,
+  params: PlanIdeaInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: PlanIdeaOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  if (!idea.github?.issueNumber) {
+    throw createError(
+      'NO_ISSUE_EXISTS',
+      'No GitHub issue exists for this idea. Create one first with idea_to_issue.',
+      params.ideaId
+    );
+  }
+
+  // Update status
+  state.updateIdeaStatus(params.ideaId, 'planning');
+
+  // Start Claude Code session in plan mode
+  const result = await sessionManager.startSession('planning', {
+    repo: idea.github.repo,
+    issueNumber: idea.github.issueNumber,
+    issueUrl: idea.github.issueUrl!,
+  });
+
+  // Record session
+  state.addSession(params.ideaId, {
+    sessionId: result.sessionId,
+    purpose: 'planning',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    claudeCodeUrl: result.claudeCodeUrl,
+  });
+
+  // Parse plan from output
+  const parsed = parseSessionOutput(result.messages);
+
+  if (parsed.plan) {
+    // Update plan with comment URL if available
+    const plan = {
+      ...parsed.plan,
+      postedAsComment: !!parsed.commentUrl,
+      commentUrl: parsed.commentUrl ?? undefined,
+    };
+
+    state.updatePlan(params.ideaId, plan);
+    state.updateIdeaStatus(params.ideaId, 'planned');
+    state.updateSessionStatus(params.ideaId, result.sessionId, 'completed');
+
+    // Notify user
+    if (parsed.commentUrl) {
+      await notificationManager.notifyPlanReady(
+        params.ideaId,
+        idea.title,
+        idea.github.issueUrl!,
+        parsed.commentUrl
+      );
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            parsed.commentUrl
+              ? `Implementation plan posted: ${parsed.commentUrl}`
+              : 'Implementation plan generated.',
+            '',
+            `Summary: ${plan.summary}`,
+            `Complexity: ${plan.estimatedComplexity}`,
+            `Steps: ${plan.steps.length}`,
+            '',
+            'To proceed, use idea_implement or request modifications.',
+          ].join('\n'),
+        },
+      ],
+      details: {
+        ideaId: idea.id,
+        sessionId: result.sessionId,
+        plan,
+        commentUrl: parsed.commentUrl ?? undefined,
+      },
+    };
+  }
+
+  // Session started but plan not yet ready (async)
+  return {
+    content: [
+      {
+        type: 'text',
+        text: [
+          'Claude Code session started for planning.',
+          '',
+          `Session URL: ${result.claudeCodeUrl}`,
+          '',
+          'The Plan agent is analyzing the codebase and generating an implementation plan.',
+          'Check idea_status for updates when the session completes.',
+        ].join('\n'),
+      },
+    ],
+    details: {
+      ideaId: idea.id,
+      sessionId: result.sessionId,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/status.ts
+++ b/plugins/idea-flow/src/tools/status.ts
@@ -1,0 +1,143 @@
+/**
+ * idea_status tool
+ * Get detailed status of a specific idea
+ */
+
+import type { StateManager } from '../state.js';
+import type { NotificationManager } from '../notifications.js';
+import type { GetIdeaStatusInput, GetIdeaStatusOutput } from '../types.js';
+import { createError } from '../errors.js';
+
+export const ideaStatusDefinition = {
+  name: 'idea_status',
+  description: 'Get detailed status of a specific idea',
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID',
+      },
+    },
+    required: ['ideaId'],
+  },
+};
+
+export async function getIdeaStatus(
+  state: StateManager,
+  notificationManager: NotificationManager,
+  params: GetIdeaStatusInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: GetIdeaStatusOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  const notifications = notificationManager.getForIdea(params.ideaId);
+  const unreadNotifications = notifications.filter((n) => !n.read);
+
+  // Mark notifications as read when viewing status
+  notificationManager.markAllRead(params.ideaId);
+
+  const lines = [
+    `Idea: "${idea.title}" [${idea.id.slice(0, 8)}]`,
+    `Status: ${idea.status}`,
+    `Created: ${new Date(idea.createdAt).toLocaleDateString()}`,
+    `Updated: ${new Date(idea.updatedAt).toLocaleDateString()}`,
+    '',
+  ];
+
+  // Repository info
+  if (idea.github) {
+    lines.push(`Repository: ${idea.github.repo}`);
+    if (idea.github.issueUrl) {
+      lines.push(`Issue: ${idea.github.issueUrl}`);
+    }
+    if (idea.github.prUrl) {
+      lines.push(`PR: ${idea.github.prUrl}`);
+    }
+    if (idea.github.branch) {
+      lines.push(`Branch: ${idea.github.branch}`);
+    }
+    lines.push('');
+  }
+
+  // Description
+  lines.push('Description:');
+  lines.push(idea.description);
+  lines.push('');
+
+  // Clarifications
+  if (idea.clarificationHistory.length > 0) {
+    lines.push(`Clarifications (${idea.clarificationHistory.length}):`);
+    for (const c of idea.clarificationHistory) {
+      lines.push(`- Q: ${c.question}`);
+      lines.push(`  A: ${c.answer}`);
+    }
+    lines.push('');
+  }
+
+  // Plan summary
+  if (idea.plan) {
+    lines.push('Plan:');
+    lines.push(`- Complexity: ${idea.plan.estimatedComplexity}`);
+    lines.push(`- Steps: ${idea.plan.steps.length}`);
+    lines.push(`- Critical files: ${idea.plan.criticalFiles.length}`);
+    if (idea.plan.commentUrl) {
+      lines.push(`- Comment: ${idea.plan.commentUrl}`);
+    }
+    lines.push('');
+  }
+
+  // Sessions
+  if (idea.sessions.length > 0) {
+    const latestSession = idea.sessions[idea.sessions.length - 1];
+    lines.push(`Latest session: ${latestSession.purpose} (${latestSession.status})`);
+    if (latestSession.claudeCodeUrl) {
+      lines.push(`Session URL: ${latestSession.claudeCodeUrl}`);
+    }
+    lines.push('');
+  }
+
+  // Unread notifications
+  if (unreadNotifications.length > 0) {
+    lines.push(`Notifications (${unreadNotifications.length} new):`);
+    for (const n of unreadNotifications) {
+      lines.push(`- [${n.type}] ${n.message.split('\n')[0]}`);
+    }
+    lines.push('');
+  }
+
+  // Suggested actions based on status
+  lines.push('Available actions:');
+  switch (idea.status) {
+    case 'draft':
+    case 'clarifying':
+      lines.push('- idea_clarify: Add more clarifications');
+      lines.push('- idea_to_issue: Create GitHub issue');
+      break;
+    case 'issue_ready':
+      lines.push('- idea_plan: Generate implementation plan');
+      lines.push('- idea_implement: Start implementation');
+      lines.push('- idea_modify: Request changes to issue');
+      lines.push('- idea_delete: Delete this idea');
+      break;
+    case 'planned':
+      lines.push('- idea_implement: Start implementation');
+      lines.push('- idea_modify: Request changes to plan');
+      break;
+    case 'implemented':
+      lines.push('- idea_modify: Request changes to implementation');
+      break;
+    default:
+      lines.push('- idea_delete: Delete this idea');
+  }
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+    details: {
+      idea,
+      pendingNotifications: unreadNotifications,
+    },
+  };
+}

--- a/plugins/idea-flow/src/tools/to-issue.ts
+++ b/plugins/idea-flow/src/tools/to-issue.ts
@@ -1,0 +1,162 @@
+/**
+ * idea_to_issue tool
+ * Create a GitHub issue from the captured idea using Claude Code
+ */
+
+import type { StateManager } from '../state.js';
+import type { ClaudeCodeSessionManager } from '../claude-code/session-manager.js';
+import type { NotificationManager } from '../notifications.js';
+import type { IdeaToIssueInput, IdeaToIssueOutput } from '../types.js';
+import { createError } from '../errors.js';
+import { parseSessionOutput } from '../claude-code/parsers.js';
+
+export const ideaToIssueDefinition = {
+  name: 'idea_to_issue',
+  description: 'Create a GitHub issue from the captured idea using Claude Code',
+  parameters: {
+    type: 'object',
+    properties: {
+      ideaId: {
+        type: 'string',
+        description: 'Idea ID to create issue for',
+      },
+      dryRun: {
+        type: 'boolean',
+        description: 'Preview the issue without creating',
+      },
+    },
+    required: ['ideaId'],
+  },
+};
+
+export async function ideaToIssue(
+  state: StateManager,
+  sessionManager: ClaudeCodeSessionManager,
+  notificationManager: NotificationManager,
+  params: IdeaToIssueInput
+): Promise<{ content: Array<{ type: string; text: string }>; details: IdeaToIssueOutput }> {
+  const idea = state.getIdea(params.ideaId);
+  if (!idea) {
+    throw createError('IDEA_NOT_FOUND', `Idea not found: ${params.ideaId}`, params.ideaId);
+  }
+
+  if (!idea.github?.repo) {
+    throw createError('CONFIGURATION_ERROR', 'No repository configured for this idea', params.ideaId);
+  }
+
+  // Dry run mode - preview only
+  if (params.dryRun) {
+    const prompt = sessionManager.buildPrompt('issue_creation', {
+      repo: idea.github.repo,
+      title: idea.title,
+      description: idea.description,
+      clarifications: idea.clarificationHistory,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            '[DRY RUN] Would create issue:',
+            '',
+            `Title: ${idea.title}`,
+            `Repository: ${idea.github.repo}`,
+            '',
+            'Prompt that would be sent to Claude Code:',
+            '---',
+            prompt,
+            '---',
+          ].join('\n'),
+        },
+      ],
+      details: {
+        ideaId: idea.id,
+        dryRun: true,
+      },
+    };
+  }
+
+  // Update status to creating
+  state.updateIdeaStatus(params.ideaId, 'issue_creating');
+
+  // Start Claude Code session for issue creation
+  const result = await sessionManager.startSession('issue_creation', {
+    repo: idea.github.repo,
+    title: idea.title,
+    description: idea.description,
+    clarifications: idea.clarificationHistory,
+  });
+
+  // Record the session
+  state.addSession(params.ideaId, {
+    sessionId: result.sessionId,
+    purpose: 'issue_creation',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    claudeCodeUrl: result.claudeCodeUrl,
+  });
+
+  // Parse results from Claude Code output
+  const parsed = parseSessionOutput(result.messages);
+
+  if (parsed.issueUrl && parsed.issueNumber) {
+    // Update GitHub artifacts
+    state.updateGitHubArtifacts(params.ideaId, {
+      issueNumber: parsed.issueNumber,
+      issueUrl: parsed.issueUrl,
+    });
+
+    // Update status
+    state.updateIdeaStatus(params.ideaId, 'issue_ready');
+    state.updateSessionStatus(params.ideaId, result.sessionId, 'completed');
+
+    // Notify user
+    await notificationManager.notifyIssueCreated(params.ideaId, idea.title, parsed.issueUrl);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            `GitHub issue created: ${parsed.issueUrl}`,
+            '',
+            'The user has been notified. They can now ask to:',
+            '- plan: Generate implementation plan',
+            '- implement: Start implementation',
+            '- modify: Change the issue',
+            '- delete: Delete this idea',
+          ].join('\n'),
+        },
+      ],
+      details: {
+        ideaId: idea.id,
+        sessionId: result.sessionId,
+        issueUrl: parsed.issueUrl,
+        issueNumber: parsed.issueNumber,
+        dryRun: false,
+      },
+    };
+  }
+
+  // Session started but issue not yet created (async)
+  return {
+    content: [
+      {
+        type: 'text',
+        text: [
+          'Claude Code session started for issue creation.',
+          '',
+          `Session URL: ${result.claudeCodeUrl}`,
+          '',
+          'Check idea_status for updates when the session completes.',
+        ].join('\n'),
+      },
+    ],
+    details: {
+      ideaId: idea.id,
+      sessionId: result.sessionId,
+      dryRun: false,
+    },
+  };
+}

--- a/plugins/idea-flow/src/types.ts
+++ b/plugins/idea-flow/src/types.ts
@@ -1,0 +1,342 @@
+/**
+ * Idea Flow Plugin Type Definitions
+ * Types for managing the idea-to-implementation pipeline
+ */
+
+// ============================================================================
+// Configuration Types
+// ============================================================================
+
+export interface PluginConfig {
+  defaultRepo: string;
+  claudeCodeEnvironment?: string;
+  statePath: string;
+  autoNotify: boolean;
+  requirePlanBeforeImplement: boolean;
+}
+
+// ============================================================================
+// Idea Types
+// ============================================================================
+
+export type IdeaStatus =
+  | 'draft'
+  | 'clarifying'
+  | 'issue_creating'
+  | 'issue_ready'
+  | 'planning'
+  | 'planned'
+  | 'implementing'
+  | 'implemented'
+  | 'completed'
+  | 'deleted';
+
+export interface Idea {
+  id: string;
+  title: string;
+  description: string;
+  status: IdeaStatus;
+  createdAt: string;
+  updatedAt: string;
+
+  // Clarification tracking
+  clarificationHistory: ClarificationEntry[];
+
+  // GitHub artifacts
+  github?: GitHubArtifacts;
+
+  // Claude Code session tracking
+  sessions: SessionRecord[];
+
+  // Implementation plan
+  plan?: ImplementationPlan;
+}
+
+export interface ClarificationEntry {
+  question: string;
+  answer: string;
+  askedAt: string;
+}
+
+export interface GitHubArtifacts {
+  repo: string;
+  issueNumber?: number;
+  issueUrl?: string;
+  prNumber?: number;
+  prUrl?: string;
+  branch?: string;
+}
+
+// ============================================================================
+// Session Types
+// ============================================================================
+
+export type SessionPurpose =
+  | 'issue_creation'
+  | 'planning'
+  | 'implementation'
+  | 'modification';
+
+export type SessionStatus = 'running' | 'completed' | 'failed';
+
+export interface SessionRecord {
+  sessionId: string;
+  purpose: SessionPurpose;
+  startedAt: string;
+  completedAt?: string;
+  status: SessionStatus;
+  claudeCodeUrl?: string;
+  error?: string;
+}
+
+// ============================================================================
+// Plan Types
+// ============================================================================
+
+export interface ImplementationPlan {
+  summary: string;
+  steps: PlanStep[];
+  criticalFiles: CriticalFile[];
+  risks: string[];
+  estimatedComplexity: 'low' | 'medium' | 'high';
+  postedAsComment: boolean;
+  commentUrl?: string;
+}
+
+export interface PlanStep {
+  order: number;
+  description: string;
+  filesInvolved: string[];
+}
+
+export interface CriticalFile {
+  path: string;
+  reason: string;
+}
+
+// ============================================================================
+// State Types
+// ============================================================================
+
+export interface PluginState {
+  ideas: Record<string, Idea>;
+  notifications: Notification[];
+  lastUpdatedAt: string | null;
+}
+
+// ============================================================================
+// Notification Types
+// ============================================================================
+
+export type NotificationType =
+  | 'issue_created'
+  | 'plan_ready'
+  | 'implementation_ready'
+  | 'modification_complete'
+  | 'error';
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  ideaId: string;
+  title: string;
+  message: string;
+  createdAt: string;
+  read: boolean;
+  issueUrl?: string;
+  prUrl?: string;
+  commentUrl?: string;
+  error?: string;
+}
+
+// ============================================================================
+// Tool Input/Output Types
+// ============================================================================
+
+// idea_capture
+export interface CaptureIdeaInput {
+  title: string;
+  description: string;
+  repo?: string;
+}
+
+export interface CaptureIdeaOutput {
+  ideaId: string;
+  status: IdeaStatus;
+  title: string;
+}
+
+// idea_clarify
+export interface ClarifyIdeaInput {
+  ideaId: string;
+  question: string;
+  answer: string;
+  updateDescription?: boolean;
+}
+
+export interface ClarifyIdeaOutput {
+  ideaId: string;
+  clarificationCount: number;
+}
+
+// idea_list
+export interface ListIdeasInput {
+  status?: IdeaStatus;
+  limit?: number;
+}
+
+export interface ListIdeasOutput {
+  ideas: IdeaSummary[];
+  totalCount: number;
+}
+
+export interface IdeaSummary {
+  id: string;
+  title: string;
+  status: IdeaStatus;
+  createdAt: string;
+  updatedAt: string;
+  hasIssue: boolean;
+  hasPlan: boolean;
+  hasPR: boolean;
+}
+
+// idea_status
+export interface GetIdeaStatusInput {
+  ideaId: string;
+}
+
+export interface GetIdeaStatusOutput {
+  idea: Idea;
+  pendingNotifications: Notification[];
+}
+
+// idea_history
+export interface GetIdeaHistoryInput {
+  ideaId: string;
+}
+
+export interface GetIdeaHistoryOutput {
+  idea: Idea;
+  clarifications: ClarificationEntry[];
+  sessions: SessionRecord[];
+}
+
+// idea_to_issue
+export interface IdeaToIssueInput {
+  ideaId: string;
+  dryRun?: boolean;
+}
+
+export interface IdeaToIssueOutput {
+  ideaId: string;
+  sessionId?: string;
+  issueUrl?: string;
+  issueNumber?: number;
+  dryRun: boolean;
+}
+
+// idea_plan
+export interface PlanIdeaInput {
+  ideaId: string;
+}
+
+export interface PlanIdeaOutput {
+  ideaId: string;
+  sessionId?: string;
+  plan?: ImplementationPlan;
+  commentUrl?: string;
+}
+
+// idea_implement
+export interface ImplementIdeaInput {
+  ideaId: string;
+  skipPlan?: boolean;
+}
+
+export interface ImplementIdeaOutput {
+  ideaId: string;
+  sessionId?: string;
+  prUrl?: string;
+  prNumber?: number;
+  branch?: string;
+}
+
+// idea_modify
+export interface ModifyIdeaInput {
+  ideaId: string;
+  modificationRequest: string;
+  target: 'issue' | 'plan' | 'implementation';
+}
+
+export interface ModifyIdeaOutput {
+  ideaId: string;
+  sessionId?: string;
+  success: boolean;
+}
+
+// idea_delete
+export interface DeleteIdeaInput {
+  ideaId: string;
+  closeIssue?: boolean;
+  closePR?: boolean;
+}
+
+export interface DeleteIdeaOutput {
+  ideaId: string;
+  deleted: boolean;
+  issueClosed: boolean;
+  prClosed: boolean;
+}
+
+// ============================================================================
+// Session Manager Types
+// ============================================================================
+
+export interface SessionParams {
+  repo: string;
+  title?: string;
+  description?: string;
+  clarifications?: ClarificationEntry[];
+  issueNumber?: number;
+  issueUrl?: string;
+  plan?: ImplementationPlan;
+  modificationRequest?: string;
+}
+
+export interface SessionStartResult {
+  sessionId: string;
+  claudeCodeUrl: string;
+  messages: StreamMessage[];
+}
+
+export interface SessionResumeResult {
+  sessionId: string;
+  messages: StreamMessage[];
+}
+
+export interface StreamMessage {
+  type: string;
+  subtype?: string;
+  content?: string;
+  session_id?: string;
+}
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+export type ErrorCode =
+  | 'IDEA_NOT_FOUND'
+  | 'INVALID_STATE_TRANSITION'
+  | 'GITHUB_ERROR'
+  | 'CLAUDE_CODE_SESSION_FAILED'
+  | 'RATE_LIMIT_EXCEEDED'
+  | 'NO_ISSUE_EXISTS'
+  | 'NO_PLAN_EXISTS'
+  | 'CONFIGURATION_ERROR';
+
+export interface RecoveryStrategy {
+  action: string;
+  message: string;
+}

--- a/plugins/idea-flow/tsconfig.json
+++ b/plugins/idea-flow/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "index.ts",
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary

- Implements complete idea-to-implementation pipeline via Claude Code web sessions
- Adds 10 tools for idea lifecycle management (capture, clarify, list, status, history, to-issue, plan, implement, modify, delete)
- Includes state management, notifications, and session tracking

## Test plan

- [ ] Configure plugin with `defaultRepo` setting
- [ ] Test idea capture and clarification workflow
- [ ] Verify GitHub issue creation via `idea_to_issue`
- [ ] Test plan generation via `idea_plan`
- [ ] Verify implementation workflow via `idea_implement`
- [ ] Test modification and deletion flows

Addresses #2

https://claude.ai/code/session_01K9k3qRscQYxLzsyGKbuntN