### PR TITLE
Add Google Calendar read-only skill

### DIFF
--- a/plugins/google-calendar/.gitignore
+++ b/plugins/google-calendar/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+*.log

--- a/plugins/google-calendar/index.ts
+++ b/plugins/google-calendar/index.ts
@@ -1,0 +1,736 @@
+/**
+ * Google Calendar Read-Only Plugin for OpenClaw
+ *
+ * This plugin provides tools for viewing Google Calendar events and availability.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OpenClawPluginApi = any;
+
+import { GoogleCalendarClient } from "./src/client.js";
+import { OAuthManager } from "./src/oauth.js";
+import { StateManager } from "./src/state.js";
+import type {
+  PluginConfig,
+  Event,
+  CalendarListEntry,
+  EventSummary,
+  EventDetail,
+  CalendarSummary,
+  FreeSlot,
+  BusySlot,
+  CalendarAvailability,
+} from "./src/types.js";
+import {
+  parseEventDateTime,
+  isAllDayEvent,
+  formatEventTimeRange,
+  formatDurationMinutes,
+  toRFC3339,
+  parseInputDate,
+  addDays,
+  addHours,
+  endOfDay,
+  getDefaultTimeRange,
+} from "./src/utils/datetime.js";
+
+// Resolve calendar ID from param -> state -> config -> "primary"
+function resolveCalendarId(
+  paramCalendarId: string | undefined,
+  state: StateManager,
+  config: PluginConfig
+): string {
+  if (paramCalendarId) return paramCalendarId;
+  const selectedCalendar = state.getSelectedCalendar();
+  if (selectedCalendar) return selectedCalendar.id;
+  if (config.defaultCalendarId) return config.defaultCalendarId;
+  return "primary";
+}
+
+// Convert API Event to EventSummary
+function eventToSummary(event: Event, calendarId: string): EventSummary {
+  const isAllDay = isAllDayEvent(event.start, event.end);
+  const startDate = parseEventDateTime(event.start);
+  const endDate = parseEventDateTime(event.end);
+
+  const videoUrl =
+    event.hangoutLink ||
+    event.conferenceData?.entryPoints?.find((e) => e.entryPointType === "video")
+      ?.uri;
+
+  const selfAttendee = event.attendees?.find((a) => a.self);
+
+  return {
+    id: event.id,
+    calendarId,
+    summary: event.summary || "(No title)",
+    description: event.description,
+    location: event.location,
+    start: isAllDay ? event.start.date! : event.start.dateTime!,
+    end: isAllDay ? event.end.date! : event.end.dateTime!,
+    isAllDay,
+    status: event.status,
+    organizer: event.organizer?.displayName || event.organizer?.email,
+    attendeeCount: event.attendees?.length || 0,
+    myResponseStatus: selfAttendee?.responseStatus,
+    hasVideoConference: !!videoUrl,
+    videoConferenceUrl: videoUrl,
+    recurringEventId: event.recurringEventId,
+    eventType: event.eventType,
+  };
+}
+
+// Convert API Event to EventDetail
+function eventToDetail(event: Event, calendarId: string): EventDetail {
+  const summary = eventToSummary(event, calendarId);
+
+  return {
+    ...summary,
+    htmlLink: event.htmlLink,
+    created: event.created,
+    updated: event.updated,
+    attendees: (event.attendees || []).map((a) => ({
+      email: a.email,
+      name: a.displayName,
+      responseStatus: a.responseStatus,
+      isOrganizer: a.organizer || false,
+      isOptional: a.optional || false,
+      isSelf: a.self || false,
+    })),
+    reminders: event.reminders?.overrides || [],
+    attachments: (event.attachments || []).map((a) => ({
+      title: a.title,
+      url: a.fileUrl,
+      mimeType: a.mimeType,
+    })),
+    recurrenceRules: event.recurrence,
+    visibility: event.visibility,
+    transparency: event.transparency,
+  };
+}
+
+// Convert CalendarListEntry to CalendarSummary
+function calendarToSummary(cal: CalendarListEntry): CalendarSummary {
+  return {
+    id: cal.id,
+    name: cal.summaryOverride || cal.summary,
+    description: cal.description,
+    timeZone: cal.timeZone,
+    isPrimary: cal.primary || false,
+    accessRole: cal.accessRole,
+    color: cal.backgroundColor,
+  };
+}
+
+// Calculate free slots from busy periods
+function calculateFreeSlots(
+  busyPeriods: Array<{ start: string; end: string }>,
+  timeMin: string,
+  timeMax: string
+): FreeSlot[] {
+  const freeSlots: FreeSlot[] = [];
+
+  // Sort busy periods by start time
+  const sorted = [...busyPeriods].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+  );
+
+  let currentTime = new Date(timeMin);
+  const endTime = new Date(timeMax);
+
+  for (const busy of sorted) {
+    const busyStart = new Date(busy.start);
+    const busyEnd = new Date(busy.end);
+
+    // If there's a gap before this busy period
+    if (currentTime < busyStart) {
+      const durationMinutes = Math.round(
+        (busyStart.getTime() - currentTime.getTime()) / (1000 * 60)
+      );
+      if (durationMinutes >= 15) {
+        // Only show slots >= 15 minutes
+        freeSlots.push({
+          start: toRFC3339(currentTime),
+          end: toRFC3339(busyStart),
+          durationMinutes,
+          durationFormatted: formatDurationMinutes(durationMinutes),
+        });
+      }
+    }
+
+    // Move current time to end of busy period
+    if (busyEnd > currentTime) {
+      currentTime = busyEnd;
+    }
+  }
+
+  // Check for free time after last busy period
+  if (currentTime < endTime) {
+    const durationMinutes = Math.round(
+      (endTime.getTime() - currentTime.getTime()) / (1000 * 60)
+    );
+    if (durationMinutes >= 15) {
+      freeSlots.push({
+        start: toRFC3339(currentTime),
+        end: toRFC3339(endTime),
+        durationMinutes,
+        durationFormatted: formatDurationMinutes(durationMinutes),
+      });
+    }
+  }
+
+  return freeSlots;
+}
+
+export default function register(api: OpenClawPluginApi) {
+  const pluginConfig = (api.pluginConfig ?? {}) as unknown as PluginConfig;
+
+  // Validate required config
+  if (!pluginConfig.clientId) {
+    console.error("Google Calendar: clientId is required in plugin config");
+    return;
+  }
+  if (!pluginConfig.clientSecret) {
+    console.error("Google Calendar: clientSecret is required in plugin config");
+    return;
+  }
+  if (!pluginConfig.refreshToken) {
+    console.error("Google Calendar: refreshToken is required in plugin config");
+    return;
+  }
+
+  // Initialize state manager
+  const state = new StateManager(
+    pluginConfig.statePath || "~/.google-calendar-state"
+  );
+
+  // Initialize OAuth manager with token persistence
+  const oauthManager = new OAuthManager({
+    clientId: pluginConfig.clientId,
+    clientSecret: pluginConfig.clientSecret,
+    initialTokens: state.getOAuthTokens() || undefined,
+    onTokensUpdated: (tokens) => {
+      state.setOAuthTokens(tokens);
+    },
+  });
+
+  // Initialize with refresh token if we don't have valid tokens
+  if (!oauthManager.hasValidTokens()) {
+    oauthManager.initializeWithRefreshToken(pluginConfig.refreshToken).catch((err) => {
+      console.error("Google Calendar: Failed to initialize OAuth:", err);
+    });
+  }
+
+  // Initialize client
+  const client = new GoogleCalendarClient(oauthManager);
+
+  const config: PluginConfig = {
+    defaultCalendarId: "primary",
+    defaultLookAheadDays: 7,
+    ...pluginConfig,
+  };
+
+  // ============================================================================
+  // Read Tools
+  // ============================================================================
+
+  // gcal_list_calendars
+  api.registerTool({
+    name: "gcal_list_calendars",
+    description:
+      "List all Google Calendar calendars the user has access to and show which one is selected",
+    parameters: {
+      type: "object",
+      properties: {
+        showHidden: {
+          type: "boolean",
+          description: "Include hidden calendars (default: false)",
+        },
+      },
+      required: [],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const response = await client.getCalendarList(
+        params.showHidden as boolean | undefined
+      );
+      const selectedCalendar = state.getSelectedCalendar();
+
+      const calendars = response.items
+        .filter((c) => !c.deleted)
+        .filter((c) => !c.hidden || params.showHidden)
+        .map(calendarToSummary)
+        .sort((a, b) => {
+          // Primary first, then alphabetical
+          if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        });
+
+      const text = [
+        `Found ${calendars.length} calendar(s):`,
+        ...calendars.map((c) => {
+          const selected = selectedCalendar?.id === c.id ? " (selected)" : "";
+          const primary = c.isPrimary ? " [primary]" : "";
+          return `- ${c.name}${primary}${selected} [${c.id}]`;
+        }),
+        "",
+        selectedCalendar
+          ? `Currently selected: ${selectedCalendar.summary}`
+          : "No calendar selected. The primary calendar will be used by default.",
+      ].join("\n");
+
+      return {
+        content: [{ type: "text", text }],
+        details: { calendars, selectedCalendarId: selectedCalendar?.id ?? null },
+      };
+    },
+  });
+
+  // gcal_list_events
+  api.registerTool({
+    name: "gcal_list_events",
+    description:
+      "List events from a Google Calendar with optional date range and search filtering",
+    parameters: {
+      type: "object",
+      properties: {
+        calendarId: {
+          type: "string",
+          description: "Calendar ID (uses selected or primary if not provided)",
+        },
+        timeMin: {
+          type: "string",
+          description:
+            "Start time (RFC3339, YYYY-MM-DD, or 'today'/'tomorrow'). Defaults to now.",
+        },
+        timeMax: {
+          type: "string",
+          description:
+            "End time (RFC3339, YYYY-MM-DD, or 'today'/'tomorrow'). Defaults to 7 days from now.",
+        },
+        maxResults: {
+          type: "number",
+          description: "Maximum events to return (default: 50)",
+        },
+        q: {
+          type: "string",
+          description: "Free-text search query to filter events",
+        },
+        singleEvents: {
+          type: "boolean",
+          description: "Expand recurring events into instances (default: true)",
+        },
+      },
+      required: [],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const calendarId = resolveCalendarId(
+        params.calendarId as string | undefined,
+        state,
+        config
+      );
+
+      // Parse time range
+      let timeMin: string;
+      let timeMax: string;
+
+      if (params.timeMin) {
+        timeMin = toRFC3339(parseInputDate(params.timeMin as string));
+      } else {
+        timeMin = toRFC3339(new Date());
+      }
+
+      if (params.timeMax) {
+        timeMax = toRFC3339(endOfDay(parseInputDate(params.timeMax as string)));
+      } else {
+        timeMax = toRFC3339(
+          endOfDay(addDays(new Date(), config.defaultLookAheadDays || 7))
+        );
+      }
+
+      const singleEvents = params.singleEvents !== false;
+
+      const response = await client.listEvents({
+        calendarId,
+        timeMin,
+        timeMax,
+        maxResults: (params.maxResults as number) || 50,
+        q: params.q as string | undefined,
+        singleEvents,
+        orderBy: singleEvents ? "startTime" : undefined,
+      });
+
+      const events = response.items
+        .filter((e) => e.status !== "cancelled")
+        .map((e) => eventToSummary(e, calendarId));
+
+      let text = `Found ${events.length} event(s):\n\n`;
+
+      if (events.length === 0) {
+        text = "No events found in the specified time range.";
+      } else {
+        for (const event of events) {
+          const timeRange = formatEventTimeRange(
+            { date: event.isAllDay ? event.start : undefined, dateTime: event.isAllDay ? undefined : event.start },
+            { date: event.isAllDay ? event.end : undefined, dateTime: event.isAllDay ? undefined : event.end },
+            config.defaultTimeZone
+          );
+          const video = event.hasVideoConference ? " [video]" : "";
+          const location = event.location ? ` @ ${event.location}` : "";
+
+          text += `- ${event.summary}${video}\n`;
+          text += `  ${timeRange}${location}\n`;
+          if (event.attendeeCount > 0) {
+            text += `  ${event.attendeeCount} attendee(s)\n`;
+          }
+          text += `  ID: ${event.id}\n\n`;
+        }
+      }
+
+      return {
+        content: [{ type: "text", text: text.trim() }],
+        details: {
+          events,
+          totalCount: events.length,
+          timeRange: { start: timeMin, end: timeMax },
+        },
+      };
+    },
+  });
+
+  // gcal_get_event
+  api.registerTool({
+    name: "gcal_get_event",
+    description: "Get detailed information about a specific calendar event",
+    parameters: {
+      type: "object",
+      properties: {
+        eventId: {
+          type: "string",
+          description: "The event ID",
+        },
+        calendarId: {
+          type: "string",
+          description: "Calendar ID (uses selected or primary if not provided)",
+        },
+      },
+      required: ["eventId"],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const calendarId = resolveCalendarId(
+        params.calendarId as string | undefined,
+        state,
+        config
+      );
+
+      const event = await client.getEvent(
+        calendarId,
+        params.eventId as string
+      );
+      const detail = eventToDetail(event, calendarId);
+
+      const timeRange = formatEventTimeRange(
+        { date: detail.isAllDay ? detail.start : undefined, dateTime: detail.isAllDay ? undefined : detail.start },
+        { date: detail.isAllDay ? detail.end : undefined, dateTime: detail.isAllDay ? undefined : detail.end },
+        config.defaultTimeZone
+      );
+
+      let text = [
+        `Event: ${detail.summary}`,
+        `━━━━━━━━━━━━━━━━━━━━`,
+        `When: ${timeRange}`,
+        detail.location ? `Where: ${detail.location}` : "",
+        detail.organizer ? `Organizer: ${detail.organizer}` : "",
+        detail.hasVideoConference
+          ? `Video: ${detail.videoConferenceUrl}`
+          : "",
+        "",
+        detail.description ? `Description:\n${detail.description}\n` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      if (detail.attendees.length > 0) {
+        text += "\nAttendees:\n";
+        for (const attendee of detail.attendees) {
+          const status =
+            attendee.responseStatus === "accepted"
+              ? "✓"
+              : attendee.responseStatus === "declined"
+              ? "✗"
+              : attendee.responseStatus === "tentative"
+              ? "?"
+              : "•";
+          const role = attendee.isOrganizer
+            ? " (organizer)"
+            : attendee.isOptional
+            ? " (optional)"
+            : "";
+          text += `  ${status} ${attendee.name || attendee.email}${role}\n`;
+        }
+      }
+
+      if (detail.attachments.length > 0) {
+        text += "\nAttachments:\n";
+        for (const attachment of detail.attachments) {
+          text += `  - ${attachment.title}: ${attachment.url}\n`;
+        }
+      }
+
+      text += `\nLink: ${detail.htmlLink}`;
+
+      return {
+        content: [{ type: "text", text }],
+        details: { event: detail },
+      };
+    },
+  });
+
+  // gcal_get_upcoming
+  api.registerTool({
+    name: "gcal_get_upcoming",
+    description:
+      "Get upcoming events in the next few hours - a quick view of what's coming up",
+    parameters: {
+      type: "object",
+      properties: {
+        calendarId: {
+          type: "string",
+          description: "Calendar ID (uses selected or primary if not provided)",
+        },
+        hours: {
+          type: "number",
+          description: "Hours to look ahead (default: 24)",
+        },
+        maxResults: {
+          type: "number",
+          description: "Maximum events to return (default: 10)",
+        },
+      },
+      required: [],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const calendarId = resolveCalendarId(
+        params.calendarId as string | undefined,
+        state,
+        config
+      );
+
+      const hours = (params.hours as number) || 24;
+      const now = new Date();
+      const timeMin = toRFC3339(now);
+      const timeMax = toRFC3339(addHours(now, hours));
+
+      const response = await client.listEvents({
+        calendarId,
+        timeMin,
+        timeMax,
+        maxResults: (params.maxResults as number) || 10,
+        singleEvents: true,
+        orderBy: "startTime",
+      });
+
+      const events = response.items
+        .filter((e) => e.status !== "cancelled")
+        .map((e) => eventToSummary(e, calendarId));
+
+      let text = `Upcoming events (next ${hours} hours):\n\n`;
+
+      if (events.length === 0) {
+        text = `No upcoming events in the next ${hours} hours.`;
+      } else {
+        for (const event of events) {
+          const timeRange = formatEventTimeRange(
+            { date: event.isAllDay ? event.start : undefined, dateTime: event.isAllDay ? undefined : event.start },
+            { date: event.isAllDay ? event.end : undefined, dateTime: event.isAllDay ? undefined : event.end },
+            config.defaultTimeZone
+          );
+          const video = event.hasVideoConference ? " [video]" : "";
+          text += `- ${event.summary}${video}\n  ${timeRange}\n\n`;
+        }
+      }
+
+      return {
+        content: [{ type: "text", text: text.trim() }],
+        details: { events, hours },
+      };
+    },
+  });
+
+  // gcal_search_events
+  api.registerTool({
+    name: "gcal_search_events",
+    description: "Search for events by text query across event titles and descriptions",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query",
+        },
+        calendarId: {
+          type: "string",
+          description: "Calendar ID (uses selected or primary if not provided)",
+        },
+        timeMin: {
+          type: "string",
+          description: "Search from date (default: 30 days ago)",
+        },
+        timeMax: {
+          type: "string",
+          description: "Search until date (default: 30 days from now)",
+        },
+        maxResults: {
+          type: "number",
+          description: "Maximum results (default: 25)",
+        },
+      },
+      required: ["query"],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const calendarId = resolveCalendarId(
+        params.calendarId as string | undefined,
+        state,
+        config
+      );
+
+      const now = new Date();
+      const timeMin = params.timeMin
+        ? toRFC3339(parseInputDate(params.timeMin as string))
+        : toRFC3339(addDays(now, -30));
+      const timeMax = params.timeMax
+        ? toRFC3339(endOfDay(parseInputDate(params.timeMax as string)))
+        : toRFC3339(endOfDay(addDays(now, 30)));
+
+      const response = await client.listEvents({
+        calendarId,
+        timeMin,
+        timeMax,
+        maxResults: (params.maxResults as number) || 25,
+        q: params.query as string,
+        singleEvents: true,
+        orderBy: "startTime",
+      });
+
+      const events = response.items
+        .filter((e) => e.status !== "cancelled")
+        .map((e) => eventToSummary(e, calendarId));
+
+      let text = `Search results for "${params.query}":\n\n`;
+
+      if (events.length === 0) {
+        text = `No events found matching "${params.query}".`;
+      } else {
+        text += `Found ${events.length} event(s):\n\n`;
+        for (const event of events) {
+          const timeRange = formatEventTimeRange(
+            { date: event.isAllDay ? event.start : undefined, dateTime: event.isAllDay ? undefined : event.start },
+            { date: event.isAllDay ? event.end : undefined, dateTime: event.isAllDay ? undefined : event.end },
+            config.defaultTimeZone
+          );
+          text += `- ${event.summary}\n  ${timeRange}\n  ID: ${event.id}\n\n`;
+        }
+      }
+
+      return {
+        content: [{ type: "text", text: text.trim() }],
+        details: { events, query: params.query },
+      };
+    },
+  });
+
+  // gcal_check_availability
+  api.registerTool({
+    name: "gcal_check_availability",
+    description:
+      "Check free/busy availability for one or more calendars in a time range",
+    parameters: {
+      type: "object",
+      properties: {
+        timeMin: {
+          type: "string",
+          description: "Start of time range (RFC3339, YYYY-MM-DD, or 'today'/'tomorrow')",
+        },
+        timeMax: {
+          type: "string",
+          description: "End of time range (RFC3339, YYYY-MM-DD, or 'today'/'tomorrow')",
+        },
+        calendarIds: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Calendar IDs to check (defaults to selected/primary calendar)",
+        },
+      },
+      required: ["timeMin", "timeMax"],
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const timeMin = toRFC3339(parseInputDate(params.timeMin as string));
+      const timeMax = toRFC3339(endOfDay(parseInputDate(params.timeMax as string)));
+
+      let calendarIds = params.calendarIds as string[] | undefined;
+      if (!calendarIds || calendarIds.length === 0) {
+        calendarIds = [resolveCalendarId(undefined, state, config)];
+      }
+
+      const response = await client.getFreeBusy({
+        timeMin,
+        timeMax,
+        calendarIds,
+      });
+
+      const calendars: CalendarAvailability[] = [];
+      const allBusySlots: BusySlot[] = [];
+
+      for (const [calId, calData] of Object.entries(response.calendars)) {
+        const errors = calData.errors?.map((e) => e.reason) || [];
+        calendars.push({
+          calendarId: calId,
+          busyPeriods: calData.busy,
+          errors: errors.length > 0 ? errors : undefined,
+        });
+
+        for (const busy of calData.busy) {
+          allBusySlots.push({
+            start: busy.start,
+            end: busy.end,
+            calendarId: calId,
+          });
+        }
+      }
+
+      const freeSlots = calculateFreeSlots(allBusySlots, timeMin, timeMax);
+
+      let text = `Availability check:\n`;
+      text += `Time range: ${new Date(timeMin).toLocaleString()} - ${new Date(timeMax).toLocaleString()}\n\n`;
+
+      if (allBusySlots.length === 0) {
+        text += "You are completely free during this time period!\n";
+      } else {
+        text += `Busy periods (${allBusySlots.length}):\n`;
+        for (const busy of allBusySlots.sort(
+          (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+        )) {
+          text += `  - ${new Date(busy.start).toLocaleString()} - ${new Date(busy.end).toLocaleString()}\n`;
+        }
+        text += "\n";
+      }
+
+      if (freeSlots.length > 0) {
+        text += `Free slots (${freeSlots.length}):\n`;
+        for (const free of freeSlots) {
+          text += `  - ${new Date(free.start).toLocaleString()} - ${new Date(free.end).toLocaleString()} (${free.durationFormatted})\n`;
+        }
+      }
+
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          calendars,
+          busySlots: allBusySlots,
+          freeSlots,
+          timeRange: { start: timeMin, end: timeMax },
+        },
+      };
+    },
+  });
+}

--- a/plugins/google-calendar/openclaw.plugin.json
+++ b/plugins/google-calendar/openclaw.plugin.json
@@ -1,0 +1,74 @@
+{
+  "id": "google-calendar",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "clientId": {
+        "type": "string",
+        "description": "Google OAuth 2.0 Client ID",
+        "sensitive": false
+      },
+      "clientSecret": {
+        "type": "string",
+        "description": "Google OAuth 2.0 Client Secret",
+        "sensitive": true
+      },
+      "refreshToken": {
+        "type": "string",
+        "description": "OAuth 2.0 Refresh Token (obtained through initial authorization)",
+        "sensitive": true
+      },
+      "defaultCalendarId": {
+        "type": "string",
+        "default": "primary",
+        "description": "Default calendar ID. Use 'primary' for the user's main calendar."
+      },
+      "statePath": {
+        "type": "string",
+        "default": "~/.google-calendar-state",
+        "description": "Path to store state and token files"
+      },
+      "defaultTimeZone": {
+        "type": "string",
+        "description": "Default timezone for date display (e.g., 'America/New_York')"
+      },
+      "defaultLookAheadDays": {
+        "type": "integer",
+        "default": 7,
+        "minimum": 1,
+        "maximum": 365,
+        "description": "Default number of days to look ahead when listing events"
+      }
+    },
+    "required": ["clientId", "clientSecret", "refreshToken"],
+    "uiHints": {
+      "clientId": {
+        "helpText": "Create OAuth credentials at console.cloud.google.com/apis/credentials"
+      },
+      "clientSecret": {
+        "inputType": "password",
+        "helpText": "Keep this secret - do not commit to version control"
+      },
+      "refreshToken": {
+        "inputType": "password",
+        "helpText": "Obtained through OAuth authorization flow"
+      },
+      "defaultCalendarId": {
+        "helpText": "Use 'primary' for your main calendar, or a specific calendar ID"
+      }
+    }
+  },
+  "tools": {
+    "read": [
+      "gcal_list_calendars",
+      "gcal_list_events",
+      "gcal_get_event",
+      "gcal_get_upcoming",
+      "gcal_search_events",
+      "gcal_check_availability"
+    ]
+  },
+  "skills": [
+    "google-calendar"
+  ]
+}

--- a/plugins/google-calendar/package.json
+++ b/plugins/google-calendar/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@openclaw/google-calendar",
+  "version": "1.0.0",
+  "description": "Google Calendar read-only plugin for OpenClaw",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "jest",
+    "lint": "eslint src/**/*.ts",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "skills"
+  ],
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "google-calendar",
+    "calendar",
+    "scheduling"
+  ],
+  "license": "MIT"
+}

--- a/plugins/google-calendar/skills/google-calendar/SKILL.md
+++ b/plugins/google-calendar/skills/google-calendar/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: google-calendar
+description: Read-only access to Google Calendar events and availability
+user-invocable: true
+---
+
+# Google Calendar
+
+This skill provides read-only access to Google Calendar, allowing you to view events, check availability, and search your calendar.
+
+## Available Tools
+
+### `gcal_list_calendars`
+List all calendars the user has access to.
+
+**Parameters:**
+- `showHidden` (boolean, optional): Include hidden calendars
+
+**Use when:** User wants to see available calendars or select a different calendar.
+
+### `gcal_list_events`
+List events from a calendar with optional filtering.
+
+**Parameters:**
+- `calendarId` (string, optional): Calendar ID (uses selected/primary if not provided)
+- `timeMin` (string, optional): Start time (RFC3339, YYYY-MM-DD, 'today', 'tomorrow')
+- `timeMax` (string, optional): End time (same formats)
+- `maxResults` (number, optional): Maximum events (default: 50)
+- `q` (string, optional): Free-text search query
+- `singleEvents` (boolean, optional): Expand recurring events (default: true)
+
+**Use when:** User asks about events in a time range, like "What's on my calendar this week?"
+
+### `gcal_get_event`
+Get detailed information about a specific event.
+
+**Parameters:**
+- `eventId` (string, required): The event ID
+- `calendarId` (string, optional): Calendar ID
+
+**Use when:** User wants details about a specific event (attendees, description, video link).
+
+### `gcal_get_upcoming`
+Quick view of events in the next few hours.
+
+**Parameters:**
+- `calendarId` (string, optional): Calendar ID
+- `hours` (number, optional): Hours to look ahead (default: 24)
+- `maxResults` (number, optional): Maximum events (default: 10)
+
+**Use when:** User asks "What's next?" or "What do I have coming up?"
+
+### `gcal_search_events`
+Search events by text query.
+
+**Parameters:**
+- `query` (string, required): Search query
+- `calendarId` (string, optional): Calendar ID
+- `timeMin` (string, optional): Search from date (default: 30 days ago)
+- `timeMax` (string, optional): Search until date (default: 30 days ahead)
+- `maxResults` (number, optional): Maximum results (default: 25)
+
+**Use when:** User wants to find events by name, like "Find all meetings with John"
+
+### `gcal_check_availability`
+Check free/busy status across calendars.
+
+**Parameters:**
+- `timeMin` (string, required): Start of time range
+- `timeMax` (string, required): End of time range
+- `calendarIds` (array, optional): Calendar IDs to check
+
+**Use when:** User asks "When am I free?" or "Am I available on Friday?"
+
+## Common Workflows
+
+### "What's on my calendar today?"
+```
+1. Call gcal_list_events with timeMin: "today", timeMax: "today"
+2. Present the list of events with times and details
+```
+
+### "When am I free this week?"
+```
+1. Call gcal_check_availability with timeMin: "today", timeMax: 7 days from now
+2. Show the free slots with durations
+```
+
+### "Find all meetings with [person]"
+```
+1. Call gcal_search_events with query: "[person's name]"
+2. Present matching events
+```
+
+### "What's my next meeting?"
+```
+1. Call gcal_get_upcoming with hours: 8, maxResults: 1
+2. If found, present the event details
+3. Optionally call gcal_get_event for full details including video link
+```
+
+## Date/Time Handling
+
+The tools accept flexible date formats:
+- RFC3339: `2026-02-05T09:00:00-08:00`
+- Date only: `2026-02-05` (interpreted as start of day)
+- Relative: `today`, `tomorrow`
+
+When displaying times to users:
+- All-day events show just the date
+- Timed events show date and time
+- Multi-day events show the full range
+
+## Error Handling
+
+- **401 Unauthorized**: The OAuth token may have expired or been revoked. The plugin will attempt to refresh automatically.
+- **403 Forbidden**: Rate limit exceeded or insufficient permissions. Wait before retrying.
+- **404 Not Found**: Calendar or event doesn't exist. Verify the ID.
+
+## Privacy Notes
+
+- This skill only has **read-only** access to calendar data
+- It cannot create, modify, or delete events
+- Calendar data may contain sensitive information (meeting titles, attendees, locations)
+- Never log or display the OAuth tokens
+
+## Configuration
+
+Required configuration:
+- `clientId`: Google OAuth 2.0 Client ID
+- `clientSecret`: Google OAuth 2.0 Client Secret
+- `refreshToken`: OAuth 2.0 Refresh Token
+
+Optional configuration:
+- `defaultCalendarId`: Default calendar (default: "primary")
+- `statePath`: State storage path (default: "~/.google-calendar-state")
+- `defaultTimeZone`: Timezone for display
+- `defaultLookAheadDays`: Days to look ahead (default: 7)

--- a/plugins/google-calendar/src/client.ts
+++ b/plugins/google-calendar/src/client.ts
@@ -1,0 +1,235 @@
+import type {
+  CalendarListResponse,
+  EventsListResponse,
+  Event,
+  FreeBusyResponse,
+  GoogleApiError,
+} from "./types.js";
+import { OAuthManager, OAuthError } from "./oauth.js";
+
+const BASE_URL = "https://www.googleapis.com/calendar/v3";
+
+export class GoogleCalendarError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public reason?: string,
+    public isRetryable: boolean = false
+  ) {
+    super(message);
+    this.name = "GoogleCalendarError";
+  }
+}
+
+export interface ListEventsParams {
+  calendarId: string;
+  timeMin?: string;
+  timeMax?: string;
+  maxResults?: number;
+  q?: string;
+  singleEvents?: boolean;
+  orderBy?: "startTime" | "updated";
+  showDeleted?: boolean;
+  pageToken?: string;
+}
+
+export interface FreeBusyParams {
+  timeMin: string;
+  timeMax: string;
+  calendarIds: string[];
+}
+
+export class GoogleCalendarClient {
+  private oauthManager: OAuthManager;
+  private lastRateLimitRemaining: number | null = null;
+
+  constructor(oauthManager: OAuthManager) {
+    this.oauthManager = oauthManager;
+  }
+
+  private async request<T>(
+    method: string,
+    endpoint: string,
+    params?: Record<string, string | number | boolean | undefined>,
+    body?: unknown
+  ): Promise<T> {
+    const accessToken = await this.oauthManager.getAccessToken();
+
+    const url = new URL(`${BASE_URL}${endpoint}`);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    };
+
+    const response = await fetch(url.toString(), {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    // Track rate limits
+    const rateLimitRemaining = response.headers.get("X-RateLimit-Remaining");
+    if (rateLimitRemaining) {
+      this.lastRateLimitRemaining = parseInt(rateLimitRemaining, 10);
+    }
+
+    if (!response.ok) {
+      await this.handleErrorResponse(response);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private async handleErrorResponse(response: Response): Promise<never> {
+    let errorData: GoogleApiError | undefined;
+    try {
+      errorData = (await response.json()) as GoogleApiError;
+    } catch {
+      // Ignore JSON parse errors
+    }
+
+    const message = errorData?.error?.message || `HTTP ${response.status}`;
+    const reason = errorData?.error?.errors?.[0]?.reason;
+
+    if (response.status === 401) {
+      throw new OAuthError(
+        "Authentication failed. Token may have been revoked.",
+        "unauthorized",
+        true
+      );
+    }
+
+    if (response.status === 403) {
+      if (reason === "rateLimitExceeded" || reason === "userRateLimitExceeded") {
+        throw new GoogleCalendarError(
+          "Google Calendar API rate limit exceeded. Please wait before making more requests.",
+          403,
+          reason,
+          true
+        );
+      }
+      throw new GoogleCalendarError(
+        `Access forbidden: ${message}`,
+        403,
+        reason
+      );
+    }
+
+    if (response.status === 404) {
+      throw new GoogleCalendarError(
+        `Not found: ${message}`,
+        404,
+        reason
+      );
+    }
+
+    if (response.status === 429) {
+      throw new GoogleCalendarError(
+        "Too many requests. Please wait before making more requests.",
+        429,
+        "rateLimitExceeded",
+        true
+      );
+    }
+
+    if (response.status >= 500) {
+      throw new GoogleCalendarError(
+        `Server error: ${message}`,
+        response.status,
+        reason,
+        true
+      );
+    }
+
+    throw new GoogleCalendarError(message, response.status, reason);
+  }
+
+  // Calendar List Operations
+
+  async getCalendarList(showHidden?: boolean): Promise<CalendarListResponse> {
+    const params: Record<string, string | boolean | undefined> = {};
+    if (showHidden !== undefined) {
+      params.showHidden = showHidden;
+    }
+    return this.request<CalendarListResponse>("GET", "/users/me/calendarList", params);
+  }
+
+  async getCalendar(calendarId: string): Promise<CalendarListResponse["items"][0]> {
+    const encodedId = encodeURIComponent(calendarId);
+    return this.request("GET", `/users/me/calendarList/${encodedId}`);
+  }
+
+  // Event Operations
+
+  async listEvents(params: ListEventsParams): Promise<EventsListResponse> {
+    const encodedCalendarId = encodeURIComponent(params.calendarId);
+    const queryParams: Record<string, string | number | boolean | undefined> = {
+      timeMin: params.timeMin,
+      timeMax: params.timeMax,
+      maxResults: params.maxResults,
+      q: params.q,
+      singleEvents: params.singleEvents,
+      orderBy: params.orderBy,
+      showDeleted: params.showDeleted,
+      pageToken: params.pageToken,
+    };
+
+    return this.request<EventsListResponse>(
+      "GET",
+      `/calendars/${encodedCalendarId}/events`,
+      queryParams
+    );
+  }
+
+  async getEvent(calendarId: string, eventId: string): Promise<Event> {
+    const encodedCalendarId = encodeURIComponent(calendarId);
+    const encodedEventId = encodeURIComponent(eventId);
+    return this.request<Event>(
+      "GET",
+      `/calendars/${encodedCalendarId}/events/${encodedEventId}`
+    );
+  }
+
+  async listAllEvents(params: ListEventsParams): Promise<Event[]> {
+    const allEvents: Event[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const response = await this.listEvents({
+        ...params,
+        pageToken,
+      });
+
+      allEvents.push(...response.items);
+      pageToken = response.nextPageToken;
+    } while (pageToken);
+
+    return allEvents;
+  }
+
+  // FreeBusy Operations
+
+  async getFreeBusy(params: FreeBusyParams): Promise<FreeBusyResponse> {
+    const body = {
+      timeMin: params.timeMin,
+      timeMax: params.timeMax,
+      items: params.calendarIds.map((id) => ({ id })),
+    };
+
+    return this.request<FreeBusyResponse>("POST", "/freeBusy", undefined, body);
+  }
+
+  // Utility Methods
+
+  getRateLimitRemaining(): number | null {
+    return this.lastRateLimitRemaining;
+  }
+}

--- a/plugins/google-calendar/src/oauth.ts
+++ b/plugins/google-calendar/src/oauth.ts
@@ -1,0 +1,159 @@
+import type { OAuthTokens, TokenRefreshResponse } from "./types.js";
+
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000; // Refresh 5 minutes early
+
+export class OAuthError extends Error {
+  constructor(
+    message: string,
+    public errorCode: string,
+    public requiresReauth: boolean = false
+  ) {
+    super(message);
+    this.name = "OAuthError";
+  }
+}
+
+export interface OAuthManagerConfig {
+  clientId: string;
+  clientSecret: string;
+  initialTokens?: OAuthTokens;
+  onTokensUpdated?: (tokens: OAuthTokens) => void;
+}
+
+export class OAuthManager {
+  private clientId: string;
+  private clientSecret: string;
+  private tokens: OAuthTokens | null = null;
+  private onTokensUpdated?: (tokens: OAuthTokens) => void;
+  private refreshPromise: Promise<void> | null = null;
+
+  constructor(config: OAuthManagerConfig) {
+    this.clientId = config.clientId;
+    this.clientSecret = config.clientSecret;
+    this.tokens = config.initialTokens || null;
+    this.onTokensUpdated = config.onTokensUpdated;
+  }
+
+  async initializeWithRefreshToken(refreshToken: string): Promise<OAuthTokens> {
+    const tokens = await this.refreshAccessToken(refreshToken);
+    this.tokens = tokens;
+    this.onTokensUpdated?.(tokens);
+    return tokens;
+  }
+
+  async getAccessToken(): Promise<string> {
+    if (!this.tokens) {
+      throw new OAuthError(
+        "No OAuth tokens available. Plugin needs to be configured with a refresh token.",
+        "no_tokens",
+        true
+      );
+    }
+
+    if (this.isTokenExpired()) {
+      await this.refresh();
+    }
+
+    return this.tokens.accessToken;
+  }
+
+  private isTokenExpired(): boolean {
+    if (!this.tokens) return true;
+    return Date.now() >= this.tokens.expiresAt - TOKEN_EXPIRY_BUFFER_MS;
+  }
+
+  private async refresh(): Promise<void> {
+    // Avoid concurrent refresh requests
+    if (this.refreshPromise) {
+      await this.refreshPromise;
+      return;
+    }
+
+    this.refreshPromise = this.doRefresh();
+    try {
+      await this.refreshPromise;
+    } finally {
+      this.refreshPromise = null;
+    }
+  }
+
+  private async doRefresh(): Promise<void> {
+    if (!this.tokens?.refreshToken) {
+      throw new OAuthError(
+        "No refresh token available. Re-authorization required.",
+        "no_refresh_token",
+        true
+      );
+    }
+
+    const newTokens = await this.refreshAccessToken(this.tokens.refreshToken);
+    this.tokens = newTokens;
+    this.onTokensUpdated?.(newTokens);
+  }
+
+  private async refreshAccessToken(refreshToken: string): Promise<OAuthTokens> {
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    });
+
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      let errorData: { error?: string; error_description?: string } = {};
+      try {
+        errorData = (await response.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+      } catch {
+        errorData = { error: "unknown", error_description: response.statusText };
+      }
+
+      if (errorData.error === "invalid_grant") {
+        throw new OAuthError(
+          "Refresh token is invalid or expired. User needs to re-authorize the application.",
+          "invalid_grant",
+          true
+        );
+      }
+
+      throw new OAuthError(
+        errorData.error_description ||
+          `Token refresh failed: ${response.status}`,
+        errorData.error || "token_refresh_failed"
+      );
+    }
+
+    const data = (await response.json()) as TokenRefreshResponse;
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: refreshToken,
+      expiresAt: Date.now() + data.expires_in * 1000,
+      tokenType: data.token_type,
+      scope: data.scope,
+    };
+  }
+
+  getTokens(): OAuthTokens | null {
+    return this.tokens;
+  }
+
+  setTokens(tokens: OAuthTokens): void {
+    this.tokens = tokens;
+  }
+
+  hasValidTokens(): boolean {
+    return this.tokens !== null && !this.isTokenExpired();
+  }
+}

--- a/plugins/google-calendar/src/state.ts
+++ b/plugins/google-calendar/src/state.ts
@@ -1,0 +1,109 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { PluginState, SelectedCalendar, OAuthTokens } from "./types.js";
+
+export class StateManager {
+  private statePath: string;
+  private stateFilePath: string;
+  private state: PluginState;
+
+  constructor(statePath: string) {
+    // Expand ~ to home directory
+    this.statePath = statePath.replace(/^~/, process.env.HOME || "");
+    this.stateFilePath = path.join(this.statePath, "state.json");
+    this.state = this.loadState();
+  }
+
+  private getDefaultState(): PluginState {
+    return {
+      selectedCalendar: null,
+      syncTokens: {},
+      lastSyncAt: null,
+      oauthTokens: null,
+    };
+  }
+
+  private loadState(): PluginState {
+    try {
+      if (!fs.existsSync(this.statePath)) {
+        fs.mkdirSync(this.statePath, { recursive: true });
+      }
+      if (fs.existsSync(this.stateFilePath)) {
+        const content = fs.readFileSync(this.stateFilePath, "utf-8");
+        const parsed = JSON.parse(content) as Partial<PluginState>;
+        return { ...this.getDefaultState(), ...parsed };
+      }
+    } catch (error) {
+      console.error("Failed to load state:", error);
+    }
+    return this.getDefaultState();
+  }
+
+  private saveState(): void {
+    try {
+      fs.mkdirSync(this.statePath, { recursive: true });
+      fs.writeFileSync(this.stateFilePath, JSON.stringify(this.state, null, 2));
+    } catch (error) {
+      console.error("Failed to save state:", error);
+    }
+  }
+
+  // Selected Calendar
+  getSelectedCalendar(): SelectedCalendar | null {
+    return this.state.selectedCalendar;
+  }
+
+  setSelectedCalendar(id: string, summary: string): void {
+    this.state.selectedCalendar = {
+      id,
+      summary,
+      selectedAt: new Date().toISOString(),
+    };
+    this.saveState();
+  }
+
+  clearSelectedCalendar(): void {
+    this.state.selectedCalendar = null;
+    this.saveState();
+  }
+
+  // OAuth Tokens
+  getOAuthTokens(): OAuthTokens | null {
+    return this.state.oauthTokens;
+  }
+
+  setOAuthTokens(tokens: OAuthTokens): void {
+    this.state.oauthTokens = tokens;
+    this.saveState();
+  }
+
+  clearOAuthTokens(): void {
+    this.state.oauthTokens = null;
+    this.saveState();
+  }
+
+  // Sync Tokens
+  getSyncToken(calendarId: string): string | undefined {
+    return this.state.syncTokens[calendarId];
+  }
+
+  setSyncToken(calendarId: string, token: string): void {
+    this.state.syncTokens[calendarId] = token;
+    this.saveState();
+  }
+
+  // Last Sync
+  getLastSyncAt(): string | null {
+    return this.state.lastSyncAt;
+  }
+
+  setLastSyncAt(timestamp: string): void {
+    this.state.lastSyncAt = timestamp;
+    this.saveState();
+  }
+
+  // Full state access
+  getState(): PluginState {
+    return { ...this.state };
+  }
+}

--- a/plugins/google-calendar/src/types.ts
+++ b/plugins/google-calendar/src/types.ts
@@ -1,0 +1,366 @@
+// ============================================================================
+// Configuration Types
+// ============================================================================
+
+export interface PluginConfig {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  defaultCalendarId?: string;
+  statePath?: string;
+  defaultTimeZone?: string;
+  defaultLookAheadDays?: number;
+}
+
+// ============================================================================
+// OAuth Types
+// ============================================================================
+
+export interface OAuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  tokenType: string;
+  scope: string;
+}
+
+export interface TokenRefreshResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+  scope: string;
+}
+
+// ============================================================================
+// Google Calendar API Response Types
+// ============================================================================
+
+export interface CalendarListResponse {
+  kind: "calendar#calendarList";
+  etag: string;
+  nextPageToken?: string;
+  nextSyncToken?: string;
+  items: CalendarListEntry[];
+}
+
+export interface EventsListResponse {
+  kind: "calendar#events";
+  etag: string;
+  summary: string;
+  description?: string;
+  updated: string;
+  timeZone: string;
+  accessRole: AccessRole;
+  nextPageToken?: string;
+  nextSyncToken?: string;
+  items: Event[];
+}
+
+export interface FreeBusyResponse {
+  kind: "calendar#freeBusy";
+  timeMin: string;
+  timeMax: string;
+  calendars: Record<string, FreeBusyCalendar>;
+}
+
+// ============================================================================
+// Calendar Types
+// ============================================================================
+
+export interface CalendarListEntry {
+  kind: "calendar#calendarListEntry";
+  etag: string;
+  id: string;
+  summary: string;
+  description?: string;
+  location?: string;
+  timeZone: string;
+  summaryOverride?: string;
+  colorId?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  hidden?: boolean;
+  selected?: boolean;
+  accessRole: AccessRole;
+  defaultReminders: Reminder[];
+  notificationSettings?: NotificationSettings;
+  primary?: boolean;
+  deleted?: boolean;
+  conferenceProperties?: ConferenceProperties;
+}
+
+export type AccessRole = "freeBusyReader" | "reader" | "writer" | "owner";
+
+export interface Reminder {
+  method: "email" | "popup";
+  minutes: number;
+}
+
+export interface NotificationSettings {
+  notifications: Notification[];
+}
+
+export interface Notification {
+  type: "eventCreation" | "eventChange" | "eventCancellation" | "eventResponse" | "agenda";
+  method: "email";
+}
+
+export interface ConferenceProperties {
+  allowedConferenceSolutionTypes: string[];
+}
+
+// ============================================================================
+// Event Types
+// ============================================================================
+
+export interface Event {
+  kind: "calendar#event";
+  etag: string;
+  id: string;
+  status: EventStatus;
+  htmlLink: string;
+  created: string;
+  updated: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  colorId?: string;
+  creator: EventPerson;
+  organizer: EventPerson;
+  start: EventDateTime;
+  end: EventDateTime;
+  endTimeUnspecified?: boolean;
+  recurrence?: string[];
+  recurringEventId?: string;
+  originalStartTime?: EventDateTime;
+  transparency?: "opaque" | "transparent";
+  visibility?: "default" | "public" | "private" | "confidential";
+  attendees?: Attendee[];
+  attendeesOmitted?: boolean;
+  hangoutLink?: string;
+  conferenceData?: ConferenceData;
+  reminders?: {
+    useDefault: boolean;
+    overrides?: Reminder[];
+  };
+  attachments?: Attachment[];
+  iCalUID: string;
+  sequence: number;
+  guestsCanInviteOthers?: boolean;
+  guestsCanModify?: boolean;
+  guestsCanSeeOtherGuests?: boolean;
+  privateCopy?: boolean;
+  locked?: boolean;
+  eventType?: EventType;
+  extendedProperties?: {
+    private?: Record<string, string>;
+    shared?: Record<string, string>;
+  };
+  source?: {
+    url: string;
+    title: string;
+  };
+}
+
+export type EventStatus = "confirmed" | "tentative" | "cancelled";
+
+export type EventType = "default" | "outOfOffice" | "focusTime" | "workingLocation";
+
+export interface EventDateTime {
+  date?: string;
+  dateTime?: string;
+  timeZone?: string;
+}
+
+export interface EventPerson {
+  id?: string;
+  email?: string;
+  displayName?: string;
+  self?: boolean;
+}
+
+export interface Attendee {
+  id?: string;
+  email: string;
+  displayName?: string;
+  organizer?: boolean;
+  self?: boolean;
+  resource?: boolean;
+  optional?: boolean;
+  responseStatus: ResponseStatus;
+  comment?: string;
+  additionalGuests?: number;
+}
+
+export type ResponseStatus = "needsAction" | "declined" | "tentative" | "accepted";
+
+export interface ConferenceData {
+  createRequest?: {
+    requestId: string;
+    conferenceSolutionKey: { type: string };
+    status: { statusCode: string };
+  };
+  entryPoints?: ConferenceEntryPoint[];
+  conferenceSolution?: {
+    key: { type: string };
+    name: string;
+    iconUri: string;
+  };
+  conferenceId?: string;
+  signature?: string;
+  notes?: string;
+}
+
+export interface ConferenceEntryPoint {
+  entryPointType: "video" | "phone" | "sip" | "more";
+  uri: string;
+  label?: string;
+  pin?: string;
+  accessCode?: string;
+  meetingCode?: string;
+  passcode?: string;
+  password?: string;
+}
+
+export interface Attachment {
+  fileUrl: string;
+  title: string;
+  mimeType: string;
+  iconLink: string;
+  fileId?: string;
+}
+
+// ============================================================================
+// FreeBusy Types
+// ============================================================================
+
+export interface FreeBusyCalendar {
+  errors?: FreeBusyError[];
+  busy: TimePeriod[];
+}
+
+export interface FreeBusyError {
+  domain: string;
+  reason: string;
+}
+
+export interface TimePeriod {
+  start: string;
+  end: string;
+}
+
+// ============================================================================
+// API Error Types
+// ============================================================================
+
+export interface GoogleApiError {
+  error: {
+    code: number;
+    message: string;
+    errors: Array<{
+      domain: string;
+      reason: string;
+      message: string;
+      locationType?: string;
+      location?: string;
+    }>;
+    status?: string;
+  };
+}
+
+// ============================================================================
+// State Types
+// ============================================================================
+
+export interface PluginState {
+  selectedCalendar: SelectedCalendar | null;
+  syncTokens: Record<string, string>;
+  lastSyncAt: string | null;
+  oauthTokens: OAuthTokens | null;
+}
+
+export interface SelectedCalendar {
+  id: string;
+  summary: string;
+  selectedAt: string;
+}
+
+// ============================================================================
+// Tool Output Types
+// ============================================================================
+
+export interface CalendarSummary {
+  id: string;
+  name: string;
+  description?: string;
+  timeZone: string;
+  isPrimary: boolean;
+  accessRole: AccessRole;
+  color?: string;
+}
+
+export interface EventSummary {
+  id: string;
+  calendarId: string;
+  summary: string;
+  description?: string;
+  location?: string;
+  start: string;
+  end: string;
+  isAllDay: boolean;
+  status: EventStatus;
+  organizer?: string;
+  attendeeCount: number;
+  myResponseStatus?: ResponseStatus;
+  hasVideoConference: boolean;
+  videoConferenceUrl?: string;
+  recurringEventId?: string;
+  eventType?: EventType;
+}
+
+export interface EventDetail extends EventSummary {
+  htmlLink: string;
+  created: string;
+  updated: string;
+  attendees: AttendeeSummary[];
+  reminders: Reminder[];
+  attachments: AttachmentSummary[];
+  recurrenceRules?: string[];
+  visibility?: string;
+  transparency?: string;
+}
+
+export interface AttendeeSummary {
+  email: string;
+  name?: string;
+  responseStatus: ResponseStatus;
+  isOrganizer: boolean;
+  isOptional: boolean;
+  isSelf: boolean;
+}
+
+export interface AttachmentSummary {
+  title: string;
+  url: string;
+  mimeType: string;
+}
+
+export interface BusySlot {
+  start: string;
+  end: string;
+  calendarId: string;
+}
+
+export interface FreeSlot {
+  start: string;
+  end: string;
+  durationMinutes: number;
+  durationFormatted: string;
+}
+
+export interface CalendarAvailability {
+  calendarId: string;
+  calendarName?: string;
+  busyPeriods: TimePeriod[];
+  errors?: string[];
+}

--- a/plugins/google-calendar/src/utils/datetime.ts
+++ b/plugins/google-calendar/src/utils/datetime.ts
@@ -1,0 +1,213 @@
+import type { EventDateTime } from "../types.js";
+
+export function parseEventDateTime(dt: EventDateTime): Date {
+  if (dt.dateTime) {
+    return new Date(dt.dateTime);
+  }
+  if (dt.date) {
+    // All-day event: date is in YYYY-MM-DD format
+    return new Date(dt.date + "T00:00:00");
+  }
+  return new Date();
+}
+
+export function isAllDayEvent(start: EventDateTime, end: EventDateTime): boolean {
+  return !start.dateTime && !!start.date && !end.dateTime && !!end.date;
+}
+
+export function formatEventTime(
+  dt: EventDateTime,
+  isAllDay: boolean,
+  timeZone?: string
+): string {
+  if (isAllDay && dt.date) {
+    return formatDate(new Date(dt.date + "T00:00:00"));
+  }
+
+  const date = parseEventDateTime(dt);
+  return formatDateTime(date, timeZone);
+}
+
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatDateTime(date: Date, timeZone?: string): string {
+  const options: Intl.DateTimeFormatOptions = {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  };
+
+  if (timeZone) {
+    options.timeZone = timeZone;
+  }
+
+  return date.toLocaleString("en-US", options);
+}
+
+export function formatTimeOnly(date: Date, timeZone?: string): string {
+  const options: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  };
+
+  if (timeZone) {
+    options.timeZone = timeZone;
+  }
+
+  return date.toLocaleTimeString("en-US", options);
+}
+
+export function formatDuration(startDate: Date, endDate: Date): string {
+  const diffMs = endDate.getTime() - startDate.getTime();
+  const diffMinutes = Math.round(diffMs / (1000 * 60));
+
+  if (diffMinutes < 60) {
+    return `${diffMinutes} minute${diffMinutes !== 1 ? "s" : ""}`;
+  }
+
+  const hours = Math.floor(diffMinutes / 60);
+  const minutes = diffMinutes % 60;
+
+  if (minutes === 0) {
+    return `${hours} hour${hours !== 1 ? "s" : ""}`;
+  }
+
+  return `${hours} hour${hours !== 1 ? "s" : ""} ${minutes} minute${minutes !== 1 ? "s" : ""}`;
+}
+
+export function formatDurationMinutes(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes} minute${minutes !== 1 ? "s" : ""}`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (remainingMinutes === 0) {
+    return `${hours} hour${hours !== 1 ? "s" : ""}`;
+  }
+
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+export function toRFC3339(date: Date): string {
+  return date.toISOString();
+}
+
+export function parseInputDate(input: string): Date {
+  // Handle YYYY-MM-DD format
+  if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    return new Date(input + "T00:00:00");
+  }
+
+  // Handle relative dates
+  const now = new Date();
+  const lower = input.toLowerCase();
+
+  if (lower === "today") {
+    return startOfDay(now);
+  }
+
+  if (lower === "tomorrow") {
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return startOfDay(tomorrow);
+  }
+
+  if (lower === "yesterday") {
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+    return startOfDay(yesterday);
+  }
+
+  // Try parsing as ISO date
+  const parsed = new Date(input);
+  if (!isNaN(parsed.getTime())) {
+    return parsed;
+  }
+
+  throw new Error(`Unable to parse date: ${input}`);
+}
+
+export function startOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+export function endOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+export function addHours(date: Date, hours: number): Date {
+  const result = new Date(date);
+  result.setTime(result.getTime() + hours * 60 * 60 * 1000);
+  return result;
+}
+
+export function getDefaultTimeRange(lookAheadDays: number): {
+  timeMin: string;
+  timeMax: string;
+} {
+  const now = new Date();
+  const end = addDays(now, lookAheadDays);
+
+  return {
+    timeMin: toRFC3339(now),
+    timeMax: toRFC3339(endOfDay(end)),
+  };
+}
+
+export function formatEventTimeRange(
+  start: EventDateTime,
+  end: EventDateTime,
+  timeZone?: string
+): string {
+  const isAllDay = isAllDayEvent(start, end);
+
+  if (isAllDay) {
+    const startDate = start.date!;
+    const endDate = end.date!;
+
+    if (startDate === endDate) {
+      return formatDate(new Date(startDate + "T00:00:00")) + " (all day)";
+    }
+
+    // Multi-day all-day event
+    const endDateParsed = new Date(endDate + "T00:00:00");
+    endDateParsed.setDate(endDateParsed.getDate() - 1); // End date is exclusive
+
+    return `${formatDate(new Date(startDate + "T00:00:00"))} - ${formatDate(endDateParsed)} (all day)`;
+  }
+
+  const startDt = parseEventDateTime(start);
+  const endDt = parseEventDateTime(end);
+
+  // Same day
+  if (startDt.toDateString() === endDt.toDateString()) {
+    return `${formatDateTime(startDt, timeZone)} - ${formatTimeOnly(endDt, timeZone)}`;
+  }
+
+  // Different days
+  return `${formatDateTime(startDt, timeZone)} - ${formatDateTime(endDt, timeZone)}`;
+}

--- a/plugins/google-calendar/tsconfig.json
+++ b/plugins/google-calendar/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "index.ts",
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}


### PR DESCRIPTION
## Summary

Implements a new OpenClaw plugin for read-only access to Google Calendar. This addresses #1.

### Tools
- `gcal_list_calendars` - List all accessible calendars
- `gcal_list_events` - List events with date/search filtering
- `gcal_get_event` - Get detailed event information
- `gcal_get_upcoming` - Quick view of upcoming events
- `gcal_search_events` - Search events by text query
- `gcal_check_availability` - Check free/busy status with free slot calculation

### Features
- OAuth 2.0 token refresh with automatic expiry handling (5-min buffer)
- Persistent state for selected calendar and tokens
- Flexible date parsing (RFC3339, YYYY-MM-DD, 'today', 'tomorrow')
- Free slot calculation from busy periods

### Files
- `plugins/google-calendar/index.ts` - Plugin entry point with tool registrations
- `plugins/google-calendar/src/types.ts` - TypeScript interfaces for Google Calendar API
- `plugins/google-calendar/src/oauth.ts` - OAuth 2.0 token management
- `plugins/google-calendar/src/client.ts` - HTTP client for Google Calendar API
- `plugins/google-calendar/src/state.ts` - State persistence
- `plugins/google-calendar/src/utils/datetime.ts` - Date/time utilities
- `plugins/google-calendar/skills/google-calendar/SKILL.md` - Agent documentation

## Test plan

- [ ] Configure plugin with Google OAuth credentials
- [ ] Test `gcal_list_calendars` lists available calendars
- [ ] Test `gcal_list_events` with various date ranges
- [ ] Test `gcal_search_events` finds events by query
- [ ] Test `gcal_check_availability` shows free/busy slots
- [ ] Verify token refresh works when access token expires

https://claude.ai/code/session_01FCAbBVzxVunGrGSswJhfEG